### PR TITLE
Force dispatchers to return awaitables to accommodate asynchronous dispatches

### DIFF
--- a/SwiftRedux.xcodeproj/project.pbxproj
+++ b/SwiftRedux.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		EE3A11D9221D7F650023B445 /* ViewController1.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEAABD42221D174B00543DE2 /* ViewController1.swift */; };
 		EE3A11DA221D7F650023B445 /* LaunchScreen.storyboard in Sources */ = {isa = PBXBuildFile; fileRef = EEAABD46221D174B00543DE2 /* LaunchScreen.storyboard */; };
 		EE3A11DB221D7F650023B445 /* Main.storyboard in Sources */ = {isa = PBXBuildFile; fileRef = EEAABD47221D174B00543DE2 /* Main.storyboard */; };
+		EE7111D52235474B00532177 /* Redux+Core.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7111D42235474B00532177 /* Redux+Core.swift */; };
 		EEFD1AAF2234A38D00C3C00E /* SwiftRedux.podspec in Resources */ = {isa = PBXBuildFile; fileRef = EEFD1AAE2234A38D00C3C00E /* SwiftRedux.podspec */; };
 		EEFD1AB12234A53D00C3C00E /* Redux+Awaitable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFD1AB02234A53D00C3C00E /* Redux+Awaitable.swift */; };
 		EEFD1AB32234A81C00C3C00E /* Redux+Awaitable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFD1AB22234A81C00C3C00E /* Redux+Awaitable.swift */; };
@@ -121,6 +122,7 @@
 		D3943ED71FA32D5600898233 /* SwiftReduxTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftReduxTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3943EDE1FA32D5600898233 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E7F56163AB1D6772064939F4 /* Pods-SwiftReduxTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftReduxTests.debug.xcconfig"; path = "Target Support Files/Pods-SwiftReduxTests/Pods-SwiftReduxTests.debug.xcconfig"; sourceTree = "<group>"; };
+		EE7111D42235474B00532177 /* Redux+Core.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+Core.swift"; sourceTree = "<group>"; };
 		EEAABD0B221D174500543DE2 /* Redux+SimpleStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+SimpleStore.swift"; sourceTree = "<group>"; };
 		EEAABD0D221D174500543DE2 /* Redux+PropInjector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+PropInjector.swift"; sourceTree = "<group>"; };
 		EEAABD0E221D174500543DE2 /* ReduxCompatibleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReduxCompatibleView.swift; sourceTree = "<group>"; };
@@ -271,6 +273,7 @@
 			children = (
 				D3943EDE1FA32D5600898233 /* Info.plist */,
 				EEFD1AB22234A81C00C3C00E /* Redux+Awaitable.swift */,
+				EE7111D42235474B00532177 /* Redux+Core.swift */,
 				D3810F5821C0CA550058FA86 /* ReduxLockTest.swift */,
 				D3300E1021B3713E00779B7F /* ReduxMiddlewareTest.swift */,
 				D30CC2FE205C40F0005B5EA1 /* ReduxPresetTest.swift */,
@@ -789,6 +792,7 @@
 				EEFD1AB32234A81C00C3C00E /* Redux+Awaitable.swift in Sources */,
 				D334ED5F21B773CA004C538E /* ReduxSagaTest+Effect.swift in Sources */,
 				D3300E1121B3713E00779B7F /* ReduxMiddlewareTest.swift in Sources */,
+				EE7111D52235474B00532177 /* Redux+Core.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftRedux/Core/Redux+Awaitable.swift
+++ b/SwiftRedux/Core/Redux+Awaitable.swift
@@ -48,14 +48,16 @@ public class Awaitable<Result> : AwaitableType {
 /// An awaitable job that does not return anything meaningful. This should be
 /// used when we do not care what the result is, but just want to provide an
 /// awaitable job implementation to conform with some requirements.
-public final class EmptyAwaitable : Awaitable<Void> {
+public final class EmptyAwaitable : Awaitable<Any> {
   
   /// Use this singleton everywhere instead of initializing new empty jobs.
   public static let instance = EmptyAwaitable()
   
   override private init() {}
   
-  override public func await() {}
+  override public func await() -> Any {
+    return Void()
+  }
 }
 
 /// An awaitable job that simply returns some specified value.

--- a/SwiftRedux/Core/Redux+Store.swift
+++ b/SwiftRedux/Core/Redux+Store.swift
@@ -20,7 +20,16 @@ public typealias ReduxStateCallback<State> = (State) -> Void
 public typealias ReduxStateGetter<State> = () -> State
 
 /// Typealias for the dispatch function.
-public typealias ReduxDispatcher = (ReduxActionType) -> Void
+public typealias ReduxDispatcher = (ReduxActionType) -> Awaitable<Any>
+
+/// Represents an action dispatcher that does not do anything.
+public class NoopDispatcher {
+  
+  /// The singleton noop dispatcher instance.
+  public static let instance: ReduxDispatcher = {_ in EmptyAwaitable.instance}
+  
+  init() {}
+}
 
 /// Typealias for the state subscribe function. Pass in the subscriber id and
 /// callback function.

--- a/SwiftRedux/Middleware+Router/Redux+Middleware+Router.swift
+++ b/SwiftRedux/Middleware+Router/Redux+Middleware+Router.swift
@@ -36,12 +36,12 @@ public struct RouterMiddleware<State, Screen: RouterScreenType>: MiddlewareProvi
         let newWrapperId = "\(wrapper.identifier)-router"
         
         return DispatchWrapper(newWrapperId) {action in
-          wrapper.dispatch(action)
-          
           if let screen = action as? Screen {
             // Force-navigate on the main thread.
             DispatchQueue.main.async {self._navigate(screen)}
           }
+          
+          return wrapper.dispatch(action)
         }
       }
     }

--- a/SwiftRedux/Middleware+Saga/Protocols+Saga.swift
+++ b/SwiftRedux/Middleware+Saga/Protocols+Saga.swift
@@ -54,7 +54,10 @@ extension SagaEffectType {
   ///   - state: A State instance.
   ///   - dispatch: The action dispatch function.
   /// - Returns: An Output instance.
-  public func invoke(withState state: State, dispatch: @escaping ReduxDispatcher) -> SagaOutput<R> {
+  public func invoke(
+    withState state: State,
+    dispatch: @escaping ReduxDispatcher = NoopDispatcher.instance)
+    -> SagaOutput<R> {
     return self.invoke(SagaInput({state}, dispatch))
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Middleware+Saga.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Middleware+Saga.swift
@@ -25,8 +25,9 @@ public struct SagaMiddleware<State>: MiddlewareProviderType {
         sagaOutputs.forEach({$0.subscribe({_ in})})
         
         return DispatchWrapper(newWrapperId) {action in
-          wrapper.dispatch(action)
-          sagaOutputs.forEach({$0.onAction(action)})
+          let dispatchResult = try! wrapper.dispatch(action).await()
+          sagaOutputs.forEach({_ = $0.onAction(action)})
+          return JustAwaitable(dispatchResult)
         }
       }
     }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Effect.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Effect.swift
@@ -22,7 +22,7 @@ public class SagaEffect<State, R>: SagaEffectType {
   init() {}
   
   public func invoke(_ input: SagaInput<State>) -> SagaOutput<R> {
-    return SagaOutput(.error(SagaError.unimplemented), {_ in})
+    return SagaOutput(.error(SagaError.unimplemented))
   }
   
   public func asEffect() -> SagaEffect<State, R> {

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Empty.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Empty.swift
@@ -9,6 +9,6 @@
 /// Empty effect whose output does not stream anything.
 public final class EmptyEffect<State, R>: SagaEffect<State, R> {
   override public func invoke(_ input: SagaInput<State>) -> SagaOutput<R> {
-    return SagaOutput(.empty(), {_ in})
+    return SagaOutput(.empty())
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Just.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Just.swift
@@ -15,6 +15,6 @@ public final class JustEffect<State, R>: SagaEffect<State, R> {
   }
   
   override public func invoke(_ input: SagaInput<State>) -> SagaOutput<R> {
-    return SagaOutput(.just(self.value), {_ in})
+    return SagaOutput(.just(self.value))
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Select.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Select.swift
@@ -16,6 +16,6 @@ public final class SelectEffect<State, R>: SagaEffect<State, R> {
   }
   
   override public func invoke(_ input: SagaInput<State>) -> SagaOutput<R> {
-    return SagaOutput(.just(self._selector(input.lastState())), {_ in})
+    return SagaOutput(.just(self._selector(input.lastState())))
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Take.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Take.swift
@@ -33,9 +33,10 @@ public class TakeEffect<State, Action, P, R>: SagaEffect<State, R> where
     let debounce = self._options.debounce
     
     return self._outputFlattener(
-      SagaOutput(paramStream, {($0 as? Action)
-        .flatMap(self._paramExtractor)
-        .map(paramStream.onNext)})
+      SagaOutput(paramStream, {
+        ($0 as? Action).flatMap(self._paramExtractor).map(paramStream.onNext)
+        return EmptyAwaitable.instance
+      })
         .debounce(bySeconds: debounce)
         .map({self._effectCreator($0).invoke(input)}))
   }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga.swift
@@ -45,7 +45,7 @@ public struct SagaOutput<T> {
   let source: Observable<T>
   private let disposeBag: DisposeBag
   
-  init(_ source: Observable<T>, _ onAction: @escaping ReduxDispatcher) {
+  init(_ source: Observable<T>, _ onAction: @escaping ReduxDispatcher = NoopDispatcher.instance) {
     self.onAction = onAction
     self.source = source
     self.disposeBag = DisposeBag()

--- a/SwiftRedux/SimpleStore/Redux+SimpleStore.swift
+++ b/SwiftRedux/SimpleStore/Redux+SimpleStore.swift
@@ -45,6 +45,7 @@ public final class SimpleStore<State>: ReduxStoreType {
   public lazy private(set) var dispatch: ReduxDispatcher = {action in
     self._lock.modify {self._state = self._reducer(self._state, action)}
     self._lock.access {self._subscribers.forEach({$0.value(self._state)})}
+    return EmptyAwaitable.instance
   }
   
   /// Subscribe to state updates and immediately receive the latest state.

--- a/SwiftReduxTests/Redux+Awaitable.swift
+++ b/SwiftReduxTests/Redux+Awaitable.swift
@@ -36,7 +36,7 @@ class AwaitableTests: XCTestCase {
     let job = EmptyAwaitable.instance
     
     /// When && Then
-    XCTAssertNotNil(job.await())
+    XCTAssertTrue(job.await() is Void)
   }
   
   func test_justAwaitable_shouldReturnSpecifiedResult() throws {

--- a/SwiftReduxTests/Redux+Core.swift
+++ b/SwiftReduxTests/Redux+Core.swift
@@ -1,0 +1,21 @@
+//
+//  Redux+Core.swift
+//  SwiftReduxTests
+//
+//  Created by Viethai Pham on 10/3/19.
+//  Copyright © 2019 Hai Pham. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftRedux
+
+class ReduxCoreTests: XCTestCase {
+  override func setUp() {
+    super.setUp()
+    _ = NoopDispatcher.init()
+  }
+  
+  public func test_noopDispatch_shouldNotDoAnything() throws {
+    XCTAssertTrue(try NoopDispatcher.instance(DefaultAction.noop).await() is Void)
+  }
+}

--- a/SwiftReduxTests/ReduxMiddlewareTest.swift
+++ b/SwiftReduxTests/ReduxMiddlewareTest.swift
@@ -26,15 +26,28 @@ extension ReduxMiddlewareTest {
     var subscribedValue = 0
     
     let middlewares: [ReduxMiddleware<State>] = [
-      {input in {wrapper in DispatchWrapper(
-        "\(wrapper.identifier)-1",
-        {data.append(1); wrapper.dispatch($0)})}},
-      {input in {wrapper in DispatchWrapper(
-        "\(wrapper.identifier)-2",
-        {data.append(2); wrapper.dispatch($0)})}},
-      {input in {wrapper in DispatchWrapper(
-        "\(wrapper.identifier)-3",
-        {data.append(3); wrapper.dispatch($0)})}}
+      {input in
+        {wrapper in DispatchWrapper("\(wrapper.identifier)-1", {
+          data.append(1)
+          _ = wrapper.dispatch($0)
+          return EmptyAwaitable.instance
+          
+        })}
+      },
+      {input in
+        {wrapper in DispatchWrapper("\(wrapper.identifier)-2", {
+          data.append(2)
+          _ = wrapper.dispatch($0)
+          return EmptyAwaitable.instance
+        })}
+      },
+      {input in
+        {wrapper in DispatchWrapper("\(wrapper.identifier)-3", {
+          data.append(3)
+          _ = wrapper.dispatch($0)
+          return EmptyAwaitable.instance
+        })}
+      }
     ]
     
     let wrapper = combineMiddlewares(middlewares)(self.store)
@@ -42,9 +55,9 @@ extension ReduxMiddlewareTest {
     let subscription = newStore.subscribeState("", {subscribedValue = $0.a})
     
     /// When
-    newStore.dispatch(DefaultAction.noop)
-    newStore.dispatch(DefaultAction.noop)
-    newStore.dispatch(DefaultAction.noop)
+    _ = newStore.dispatch(DefaultAction.noop)
+    _ = newStore.dispatch(DefaultAction.noop)
+    _ = newStore.dispatch(DefaultAction.noop)
     
     /// Then
     XCTAssertEqual(wrapper.identifier, "root-3-2-1")

--- a/SwiftReduxTests/ReduxRouterTest.swift
+++ b/SwiftReduxTests/ReduxRouterTest.swift
@@ -17,7 +17,12 @@ final class ReduxRouterTest: XCTestCase {
   override func setUp() {
     super.setUp()
     let input = MiddlewareInput({()})
-    let wrapper = DispatchWrapper("", {_ in self.dispatchCount += 1})
+    
+    let wrapper = DispatchWrapper("", {_ in
+      self.dispatchCount += 1
+      return EmptyAwaitable.instance
+    })
+    
     self.router = ReduxRouter()
     self.dispatchCount = 0
 
@@ -33,10 +38,10 @@ extension ReduxRouterTest {
     self.router.navigateCallback = { if $0 == 3 { expect.fulfill() } }
     
     /// When
-    self.dispatch(Screen.login)
-    self.dispatch(Screen.dashboard)
-    self.dispatch(Screen.login)
-    self.dispatch(DefaultAction.noop)
+    _ = self.dispatch(Screen.login)
+    _ = self.dispatch(Screen.dashboard)
+    _ = self.dispatch(Screen.login)
+    _ = self.dispatch(DefaultAction.noop)
     
     /// Then
     waitForExpectations(timeout: 10, handler: nil)

--- a/SwiftReduxTests/ReduxSagaTest+Effect.swift
+++ b/SwiftReduxTests/ReduxSagaTest+Effect.swift
@@ -17,13 +17,18 @@ final class ReduxSagaEffectTest: XCTestCase {
   func test_baseEffect_shouldThrowUnimplementedError() {
     /// Setup
     var dispatchCount = 0
-    let dispatch: ReduxDispatcher = {_ in dispatchCount += 1}
+    
+    let dispatch: ReduxDispatcher = {_ in
+      dispatchCount += 1
+      return EmptyAwaitable.instance
+    }
+    
     let effect = SagaEffect<State, Int>()
     let output = effect.invoke(withState: (), dispatch: dispatch)
     
     /// When
-    dispatch(DefaultAction.noop)
-    output.onAction(DefaultAction.noop)
+    _ = dispatch(DefaultAction.noop)
+    _ = output.onAction(DefaultAction.noop)
     let value = output.nextValue(timeoutInSeconds: self.timeout)
     
     /// Then
@@ -34,7 +39,7 @@ final class ReduxSagaEffectTest: XCTestCase {
   
   func test_callEffect_shouldPerformAsyncWork() {
     /// Setup
-    let dispatch: ReduxDispatcher = {_ in}
+    let dispatch = NoopDispatcher.instance
     let error = SagaError.unimplemented
     
     let api1: (Int, @escaping (Try<Int>) -> Void) -> Void = {param, callback in
@@ -96,8 +101,8 @@ final class ReduxSagaEffectTest: XCTestCase {
     }
     
     let caught = source.catchError({_ in 100})
-    let output1 = source.invoke(withState: (), dispatch: {_ in})
-    let output2 = caught.invoke(withState: (), dispatch: {_ in})
+    let output1 = source.invoke(withState: ())
+    let output2 = caught.invoke(withState: ())
     
     /// When
     let value1 = output1.nextValue(timeoutInSeconds: self.timeout)
@@ -113,8 +118,8 @@ final class ReduxSagaEffectTest: XCTestCase {
     let source = SagaEffect<State, String>.just("a")
     let effect1 = source.compactMap(Int.init)
     let effect2 = source.compactMap({$0 + "b"})
-    let output1 = effect1.invoke(withState: (), dispatch: {_ in})
-    let output2 = effect2.invoke(withState: (), dispatch: {_ in})
+    let output1 = effect1.invoke(withState: ())
+    let output2 = effect2.invoke(withState: ())
     
     /// When
     let value1 = output1.nextValue(timeoutInSeconds: self.timeout)
@@ -128,15 +133,19 @@ final class ReduxSagaEffectTest: XCTestCase {
   func test_delayEffect_shouldDelayEmission() {
     /// Setup
     var dispatchCount = 0
-    let dispatch: ReduxDispatcher = {_ in dispatchCount += 1}
+    
+    let dispatch: ReduxDispatcher = {_ in
+      dispatchCount += 1
+      return EmptyAwaitable.instance
+    }
     
     let output = SagaEffect<State, Int>.just(400)
       .delay(bySeconds: 2, usingQueue: .global(qos: .background))
       .invoke(withState: (), dispatch: dispatch)
     
     /// When
-    dispatch(DefaultAction.noop)
-    output.onAction(DefaultAction.noop)
+    _ = dispatch(DefaultAction.noop)
+    _ = output.onAction(DefaultAction.noop)
     let value = output.nextValue(timeoutInSeconds: self.timeout)
     
     /// Then
@@ -161,8 +170,8 @@ final class ReduxSagaEffectTest: XCTestCase {
       .call(with: .just(1), callCreator: {$1(nil, SagaError.unimplemented)})
       .transform(with: transformer)
     
-    let valueOutput = valueSource.invoke(withState: (), dispatch: {_ in})
-    let errorOutput = errorSource.invoke(withState: (), dispatch: {_ in})
+    let valueOutput = valueSource.invoke(withState: ())
+    let errorOutput = errorSource.invoke(withState: ())
     
     /// When
     _ = valueOutput.nextValue(timeoutInSeconds: self.timeout)
@@ -176,13 +185,18 @@ final class ReduxSagaEffectTest: XCTestCase {
   func test_emptyEffect_shouldNotEmitAnything() {
     /// Setup
     var dispatchCount = 0
-    let dispatch: ReduxDispatcher = {_ in dispatchCount += 1}
+    
+    let dispatch: ReduxDispatcher = {_ in
+      dispatchCount += 1
+      return EmptyAwaitable.instance
+    }
+    
     let effect = SagaEffect<State, Int>.empty()
     let output = effect.invoke(withState: (), dispatch: dispatch)
     
     /// When
-    dispatch(DefaultAction.noop)
-    output.onAction(DefaultAction.noop)
+    _ = dispatch(DefaultAction.noop)
+    _ = output.onAction(DefaultAction.noop)
     let value = output.nextValue(timeoutInSeconds: self.timeout / 2)
     
     /// Then
@@ -195,8 +209,8 @@ final class ReduxSagaEffectTest: XCTestCase {
     let source = SagaEffect<State, Int>.just(1)
     let effect1 = source.filter({$0 % 2 == 0})
     let effect2 = source.filter({$0 % 2 == 1})
-    let output1 = effect1.invoke(withState: (), dispatch: {_ in})
-    let output2 = effect2.invoke(withState: (), dispatch: {_ in})
+    let output1 = effect1.invoke(withState: ())
+    let output2 = effect2.invoke(withState: ())
     
     /// When
     let value1 = output1.nextValue(timeoutInSeconds: self.timeout)
@@ -210,13 +224,18 @@ final class ReduxSagaEffectTest: XCTestCase {
   func test_justEffect_shouldEmitOnlyOneValue() {
     /// Setup
     var dispatchCount = 0
-    let dispatch: ReduxDispatcher = {_ in dispatchCount += 1}
+    
+    let dispatch: ReduxDispatcher = {_ in
+      dispatchCount += 1
+      return EmptyAwaitable.instance
+    }
+    
     let effect = SagaEffect<State, Int>.just(10)
     let output = effect.invoke(withState: (), dispatch: dispatch)
     
     /// When
-    dispatch(DefaultAction.noop)
-    output.onAction(DefaultAction.noop)
+    _ = dispatch(DefaultAction.noop)
+    _ = output.onAction(DefaultAction.noop)
     let value1 = output.nextValue(timeoutInSeconds: self.timeout)
     let value2 = output.nextValue(timeoutInSeconds: self.timeout)
     let value3 = output.nextValue(timeoutInSeconds: self.timeout)
@@ -229,7 +248,7 @@ final class ReduxSagaEffectTest: XCTestCase {
   func test_mapEffect_shouldMapInnerValue() {
     /// Setup
     let effect = SagaEffect<State, Int>.just(1).map({$0 * 10})
-    let output = effect.invoke(withState: (), dispatch: {_ in})
+    let output = effect.invoke(withState: ())
     
     /// When
     let value = output.nextValue(timeoutInSeconds: self.timeout)
@@ -250,6 +269,7 @@ final class ReduxSagaEffectTest: XCTestCase {
       dispatchCount += 1
       actions.append($0)
       if dispatchCount == 2 { expect.fulfill() }
+      return EmptyAwaitable.instance
     }
     
     let queue = DispatchQueue.global(qos: .background)
@@ -259,8 +279,8 @@ final class ReduxSagaEffectTest: XCTestCase {
     let output2 = effect2.invoke(withState: (), dispatch: dispatch)
     
     /// When
-    output1.onAction(DefaultAction.noop)
-    output2.onAction(DefaultAction.noop)
+    _ = output1.onAction(DefaultAction.noop)
+    _ = output2.onAction(DefaultAction.noop)
     _ = output1.nextValue(timeoutInSeconds: self.timeout)
     _ = output2.nextValue(timeoutInSeconds: self.timeout)
     waitForExpectations(timeout: self.timeout, handler: nil)
@@ -284,13 +304,18 @@ final class ReduxSagaEffectTest: XCTestCase {
   func test_selectEffect_shouldEmitOnlySelectedStateValue() {
     /// Setup
     var dispatchCount = 0
-    let dispatch: ReduxDispatcher = {_ in dispatchCount += 1}
+    
+    let dispatch: ReduxDispatcher = {_ in
+      dispatchCount += 1
+      return EmptyAwaitable.instance
+    }
+    
     let effect = SagaEffect<State, Int>.select({_ in 100})
     let output = effect.invoke(withState: (), dispatch: dispatch)
     
     /// When
-    dispatch(DefaultAction.noop)
-    output.onAction(DefaultAction.noop)
+    _ = dispatch(DefaultAction.noop)
+    _ = output.onAction(DefaultAction.noop)
     let value1 = output.nextValue(timeoutInSeconds: self.timeout)
     let value2 = output.nextValue(timeoutInSeconds: self.timeout)
     let value3 = output.nextValue(timeoutInSeconds: self.timeout)
@@ -309,7 +334,7 @@ final class ReduxSagaEffectTest: XCTestCase {
     }
     
     let sequence = effect1.then(2)
-    let output = sequence.invoke(withState: (), dispatch: {_ in})
+    let output = sequence.invoke(withState: ())
     
     /// When
     let value = output.nextValue(timeoutInSeconds: self.timeout)
@@ -338,7 +363,11 @@ extension ReduxSagaEffectTest {
   {
     /// Setup
     var dispatchCount = 0
-    let dispatch: ReduxDispatcher = {_ in dispatchCount += 1}
+    
+    let dispatch: ReduxDispatcher = {_ in
+      dispatchCount += 1
+      return EmptyAwaitable.instance
+    }
     
     let callEffectCreator: (Int) -> SagaEffect<State, Int> = {
       SagaEffect.call(with: .just($0)) {
@@ -353,11 +382,11 @@ extension ReduxSagaEffectTest {
     
     /// When
     output.subscribe({values.append($0)})
-    output.onAction(TakeAction.a)
-    output.onAction(TakeAction.b)
-    output.onAction(TakeAction.a)
-    output.onAction(DefaultAction.noop)
-    output.onAction(TakeAction.a)
+    _ = output.onAction(TakeAction.a)
+    _ = output.onAction(TakeAction.b)
+    _ = output.onAction(TakeAction.a)
+    _ = output.onAction(DefaultAction.noop)
+    _ = output.onAction(TakeAction.a)
     
     /// Then
     let waitTime = UInt64(pow(10 as Double, 9) * 3)
@@ -399,16 +428,16 @@ extension ReduxSagaEffectTest {
       effectCreator: {.just($0)},
       options: options)
     
-    let output = effect.invoke(withState: (), dispatch: {_ in})
+    let output = effect.invoke(withState: ())
     var values = [Int]()
     
     /// When
     output.subscribe({values.append($0)})
-    output.onAction(TakeAction.a)
-    output.onAction(TakeAction.a)
-    output.onAction(TakeAction.a)
-    output.onAction(TakeAction.a)
-    output.onAction(TakeAction.a)
+    _ = output.onAction(TakeAction.a)
+    _ = output.onAction(TakeAction.a)
+    _ = output.onAction(TakeAction.a)
+    _ = output.onAction(TakeAction.a)
+    _ = output.onAction(TakeAction.a)
     
     /// Then
     let waitTime = UInt64(pow(10 as Double, 9) * 3)

--- a/SwiftReduxTests/ReduxSagaTest.swift
+++ b/SwiftReduxTests/ReduxSagaTest.swift
@@ -18,7 +18,12 @@ final class ReduxSagaTest: XCTestCase {
   override func setUp() {
     super.setUp()
     let input = MiddlewareInput({()})
-    let wrapper = DispatchWrapper("", {_ in self.dispatchCount += 1})
+    
+    let wrapper = DispatchWrapper("") {_ in
+      self.dispatchCount += 1
+      return EmptyAwaitable.instance
+    }
+    
     self.dispatchCount = 0
     self.testEffect = TestEffect()
 
@@ -35,10 +40,10 @@ extension ReduxSagaTest {
   
   func test_receivingAction_shouldInvokeSagaEffects() {
     /// Setup && When
-    self.dispatch(DefaultAction.noop)
-    self.dispatch(DefaultAction.noop)
-    self.dispatch(DefaultAction.noop)
-    self.dispatch(DefaultAction.noop)
+    _ = self.dispatch(DefaultAction.noop)
+    _ = self.dispatch(DefaultAction.noop)
+    _ = self.dispatch(DefaultAction.noop)
+    _ = self.dispatch(DefaultAction.noop)
     
     /// Then
     XCTAssertEqual(self.testEffect.invokeCount, 1)
@@ -50,8 +55,7 @@ extension ReduxSagaTest {
   
   func test_transformingOut_shouldWork() {
     /// Setup
-    let output = SagaOutput
-      .init(.just(0), {_ in})
+    let output = SagaOutput(.just(0))
       .map({$0 + 1})
       .debounce(bySeconds: 1)
       .printValue()
@@ -85,6 +89,7 @@ extension ReduxSagaTest {
       return SagaOutput(.just(input.lastState())) {
         self.onActionCount += 1
         self.pastActions.append($0)
+        return EmptyAwaitable.instance
       }
     }
   }

--- a/SwiftReduxTests/ReduxStoreTest.swift
+++ b/SwiftReduxTests/ReduxStoreTest.swift
@@ -66,10 +66,10 @@ extension ReduxStoreTest {
       if async {
         actions.forEach({action in
           let qos = qoses.randomElement()!
-          DispatchQueue.global(qos: qos).async{store.dispatch(action)}
+          DispatchQueue.global(qos: qos).async{_ = store.dispatch(action)}
         })
       } else {
-        actions.forEach(store.dispatch)
+        actions.forEach({_ = store.dispatch($0)})
       }
     }
 
@@ -100,9 +100,9 @@ extension ReduxStoreTest {
     let subscription = store.subscribeState("", {_ in callbackCount += 1})
     
     /// When
-    (0..<iterations).forEach({_ in store.dispatch(Action.add)})
+    (0..<iterations).forEach({_ in _ = store.dispatch(Action.add)})
     subscription.unsubscribe()
-    (0..<iterations).forEach({_ in store.dispatch(Action.add)})
+    (0..<iterations).forEach({_ in _ = store.dispatch(Action.add)})
     
     /// Then
     XCTAssertEqual(callbackCount, iterations + 1)

--- a/SwiftReduxTests/ReduxUITest.swift
+++ b/SwiftReduxTests/ReduxUITest.swift
@@ -162,9 +162,7 @@ extension ReduxUITests {
       return {self.state}
     }
     
-    var dispatch: ReduxDispatcher {
-      return {_ in}
-    }
+    var dispatch = NoopDispatcher.instance
     
     var subscribeState: ReduxSubscriber<State> {
       return {
@@ -233,7 +231,7 @@ extension ReduxUITests.ViewController: PropMapperType {
   static func mapAction(dispatch: @escaping ReduxDispatcher,
                         state: ReduxState,
                         outProps: OutProps) -> ActionProps {
-    return {dispatch(DefaultAction.noop)}
+    return {_ = dispatch(DefaultAction.noop)}
   }
 }
 
@@ -252,7 +250,7 @@ extension ReduxUITests.View: PropMapperType {
   static func mapAction(dispatch: @escaping ReduxDispatcher,
                         state: ReduxState,
                         outProps: OutProps) -> ActionProps {
-    return {dispatch(DefaultAction.noop)}
+    return {_ = dispatch(DefaultAction.noop)}
   }
 }
 


### PR DESCRIPTION
The name pretty much says it all:

```swift
typealias ReduxDispatcher = (ReduxActionType) -> Awaitable<Any>
```