### PR TITLE
Unique ID provider

### DIFF
--- a/SwiftRedux.xcodeproj/project.pbxproj
+++ b/SwiftRedux.xcodeproj/project.pbxproj
@@ -71,6 +71,8 @@
 		EE3A11D9221D7F650023B445 /* ViewController1.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEAABD42221D174B00543DE2 /* ViewController1.swift */; };
 		EE3A11DA221D7F650023B445 /* LaunchScreen.storyboard in Sources */ = {isa = PBXBuildFile; fileRef = EEAABD46221D174B00543DE2 /* LaunchScreen.storyboard */; };
 		EE3A11DB221D7F650023B445 /* Main.storyboard in Sources */ = {isa = PBXBuildFile; fileRef = EEAABD47221D174B00543DE2 /* Main.storyboard */; };
+		EE567CF02236BE0D00E907F4 /* Redux+UniqueID.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE567CEF2236BE0D00E907F4 /* Redux+UniqueID.swift */; };
+		EE567CF22236BF5200E907F4 /* Redux+UniqueID.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE567CF12236BF5200E907F4 /* Redux+UniqueID.swift */; };
 		EE7111D52235474B00532177 /* Redux+Core.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7111D42235474B00532177 /* Redux+Core.swift */; };
 		EE7111DB2235756400532177 /* Redux+Saga+Output.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7111DA2235756300532177 /* Redux+Saga+Output.swift */; };
 		EEFD1AAF2234A38D00C3C00E /* SwiftRedux.podspec in Resources */ = {isa = PBXBuildFile; fileRef = EEFD1AAE2234A38D00C3C00E /* SwiftRedux.podspec */; };
@@ -129,6 +131,8 @@
 		D3943ED71FA32D5600898233 /* SwiftReduxTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftReduxTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3943EDE1FA32D5600898233 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E7F56163AB1D6772064939F4 /* Pods-SwiftReduxTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftReduxTests.debug.xcconfig"; path = "Target Support Files/Pods-SwiftReduxTests/Pods-SwiftReduxTests.debug.xcconfig"; sourceTree = "<group>"; };
+		EE567CEF2236BE0D00E907F4 /* Redux+UniqueID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+UniqueID.swift"; sourceTree = "<group>"; };
+		EE567CF12236BF5200E907F4 /* Redux+UniqueID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Redux+UniqueID.swift"; sourceTree = "<group>"; };
 		EE7111D42235474B00532177 /* Redux+Core.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+Core.swift"; sourceTree = "<group>"; };
 		EE7111DA2235756300532177 /* Redux+Saga+Output.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Redux+Saga+Output.swift"; sourceTree = "<group>"; };
 		EEAABD0B221D174500543DE2 /* Redux+SimpleStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+SimpleStore.swift"; sourceTree = "<group>"; };
@@ -288,6 +292,7 @@
 				D3943EDE1FA32D5600898233 /* Info.plist */,
 				EEFD1AB22234A81C00C3C00E /* Redux+Awaitable.swift */,
 				EE7111D42235474B00532177 /* Redux+Core.swift */,
+				EE567CEF2236BE0D00E907F4 /* Redux+UniqueID.swift */,
 				D3810F5821C0CA550058FA86 /* ReduxLockTest.swift */,
 				D3300E1021B3713E00779B7F /* ReduxMiddlewareTest.swift */,
 				D30CC2FE205C40F0005B5EA1 /* ReduxPresetTest.swift */,
@@ -443,10 +448,11 @@
 			isa = PBXGroup;
 			children = (
 				EEAABD3A221D174500543DE2 /* Protocols.swift */,
+				EEFD1AB02234A53D00C3C00E /* Redux+Awaitable.swift */,
 				EEAABD1A221D174500543DE2 /* Redux+Preset.swift */,
 				EEAABD20221D174500543DE2 /* Redux+RWLock.swift */,
 				EEAABD3D221D174500543DE2 /* Redux+Store.swift */,
-				EEFD1AB02234A53D00C3C00E /* Redux+Awaitable.swift */,
+				EE567CF12236BF5200E907F4 /* Redux+UniqueID.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -767,6 +773,7 @@
 				EE7111DB2235756400532177 /* Redux+Saga+Output.swift in Sources */,
 				EE3A11B9221D7F4A0023B445 /* Redux+Saga+Effects.swift in Sources */,
 				EE3A11BA221D7F4A0023B445 /* Redux+Saga+Do.swift in Sources */,
+				EE567CF22236BF5200E907F4 /* Redux+UniqueID.swift in Sources */,
 				EE3A11BB221D7F4A0023B445 /* Redux+Saga+Call.swift in Sources */,
 				EE3A11BC221D7F4A0023B445 /* Redux+Saga+Just.swift in Sources */,
 				EE3A11BD221D7F4A0023B445 /* Redux+Saga+Map.swift in Sources */,
@@ -800,6 +807,7 @@
 				EEFD1AB32234A81C00C3C00E /* Redux+Awaitable.swift in Sources */,
 				D334ED5F21B773CA004C538E /* ReduxSagaTest+Effect.swift in Sources */,
 				D3300E1121B3713E00779B7F /* ReduxMiddlewareTest.swift in Sources */,
+				EE567CF02236BE0D00E907F4 /* Redux+UniqueID.swift in Sources */,
 				EE7111D52235474B00532177 /* Redux+Core.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SwiftRedux.xcodeproj/project.pbxproj
+++ b/SwiftRedux.xcodeproj/project.pbxproj
@@ -73,6 +73,8 @@
 		EE3A11DB221D7F650023B445 /* Main.storyboard in Sources */ = {isa = PBXBuildFile; fileRef = EEAABD47221D174B00543DE2 /* Main.storyboard */; };
 		EE567CF02236BE0D00E907F4 /* Redux+UniqueID.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE567CEF2236BE0D00E907F4 /* Redux+UniqueID.swift */; };
 		EE567CF22236BF5200E907F4 /* Redux+UniqueID.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE567CF12236BF5200E907F4 /* Redux+UniqueID.swift */; };
+		EE567CF42236C2C600E907F4 /* Redux+Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE567CF32236C2C600E907F4 /* Redux+Subscription.swift */; };
+		EE567CF62236C94A00E907F4 /* Redux+Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE567CF52236C94A00E907F4 /* Redux+Subscription.swift */; };
 		EE7111D52235474B00532177 /* Redux+Core.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7111D42235474B00532177 /* Redux+Core.swift */; };
 		EE7111DB2235756400532177 /* Redux+Saga+Output.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7111DA2235756300532177 /* Redux+Saga+Output.swift */; };
 		EEFD1AAF2234A38D00C3C00E /* SwiftRedux.podspec in Resources */ = {isa = PBXBuildFile; fileRef = EEFD1AAE2234A38D00C3C00E /* SwiftRedux.podspec */; };
@@ -133,6 +135,8 @@
 		E7F56163AB1D6772064939F4 /* Pods-SwiftReduxTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftReduxTests.debug.xcconfig"; path = "Target Support Files/Pods-SwiftReduxTests/Pods-SwiftReduxTests.debug.xcconfig"; sourceTree = "<group>"; };
 		EE567CEF2236BE0D00E907F4 /* Redux+UniqueID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+UniqueID.swift"; sourceTree = "<group>"; };
 		EE567CF12236BF5200E907F4 /* Redux+UniqueID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Redux+UniqueID.swift"; sourceTree = "<group>"; };
+		EE567CF32236C2C600E907F4 /* Redux+Subscription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Redux+Subscription.swift"; sourceTree = "<group>"; };
+		EE567CF52236C94A00E907F4 /* Redux+Subscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+Subscription.swift"; sourceTree = "<group>"; };
 		EE7111D42235474B00532177 /* Redux+Core.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+Core.swift"; sourceTree = "<group>"; };
 		EE7111DA2235756300532177 /* Redux+Saga+Output.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Redux+Saga+Output.swift"; sourceTree = "<group>"; };
 		EEAABD0B221D174500543DE2 /* Redux+SimpleStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+SimpleStore.swift"; sourceTree = "<group>"; };
@@ -292,6 +296,7 @@
 				D3943EDE1FA32D5600898233 /* Info.plist */,
 				EEFD1AB22234A81C00C3C00E /* Redux+Awaitable.swift */,
 				EE7111D42235474B00532177 /* Redux+Core.swift */,
+				EE567CF52236C94A00E907F4 /* Redux+Subscription.swift */,
 				EE567CEF2236BE0D00E907F4 /* Redux+UniqueID.swift */,
 				D3810F5821C0CA550058FA86 /* ReduxLockTest.swift */,
 				D3300E1021B3713E00779B7F /* ReduxMiddlewareTest.swift */,
@@ -384,9 +389,9 @@
 		EEAABD3F221D174500543DE2 /* SwiftRedux */ = {
 			isa = PBXGroup;
 			children = (
-				EEFD1AAD2234A37200C3C00E /* Core */,
 				EEAABD3B221D174500543DE2 /* SwiftRedux.h */,
 				EEAABD3C221D174500543DE2 /* Info.plist */,
+				EEFD1AAD2234A37200C3C00E /* Core */,
 				EEAABD16221D174500543DE2 /* Middleware */,
 				EEAABD39221D174500543DE2 /* Middleware+Router */,
 				EEAABD35221D174500543DE2 /* Middleware+Saga */,
@@ -452,6 +457,7 @@
 				EEAABD1A221D174500543DE2 /* Redux+Preset.swift */,
 				EEAABD20221D174500543DE2 /* Redux+RWLock.swift */,
 				EEAABD3D221D174500543DE2 /* Redux+Store.swift */,
+				EE567CF32236C2C600E907F4 /* Redux+Subscription.swift */,
 				EE567CF12236BF5200E907F4 /* Redux+UniqueID.swift */,
 			);
 			path = Core;
@@ -779,6 +785,7 @@
 				EE3A11BD221D7F4A0023B445 /* Redux+Saga+Map.swift in Sources */,
 				EE3A11BE221D7F4A0023B445 /* Redux+Saga+Unwrap.swift in Sources */,
 				EE3A11BF221D7F4A0023B445 /* Redux+Saga+Put.swift in Sources */,
+				EE567CF42236C2C600E907F4 /* Redux+Subscription.swift in Sources */,
 				EE3A11C0221D7F4A0023B445 /* Redux+Saga+Empty.swift in Sources */,
 				EE3A11C1221D7F4A0023B445 /* Redux+Preset.swift in Sources */,
 				EE3A11C5221D7F4A0023B445 /* Redux+SimpleStore.swift in Sources */,
@@ -809,6 +816,7 @@
 				D3300E1121B3713E00779B7F /* ReduxMiddlewareTest.swift in Sources */,
 				EE567CF02236BE0D00E907F4 /* Redux+UniqueID.swift in Sources */,
 				EE7111D52235474B00532177 /* Redux+Core.swift in Sources */,
+				EE567CF62236C94A00E907F4 /* Redux+Subscription.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftRedux/Core/Protocols.swift
+++ b/SwiftRedux/Core/Protocols.swift
@@ -41,6 +41,14 @@ public protocol ReduxStoreType {
   var subscribeState: ReduxSubscriber<State> { get }
 }
 
+/// Represents an object that has a unique ID.
+public protocol UniqueIDProviderType {
+  typealias UniqueID = Int64
+  
+  /// The unique ID of this object.
+  var uniqueID: UniqueID { get }
+}
+
 /// Implement this protocol to provide read-write lock capabilities.
 public protocol ReadWriteLockType {
   

--- a/SwiftRedux/Core/Redux+Store.swift
+++ b/SwiftRedux/Core/Redux+Store.swift
@@ -11,7 +11,7 @@
 public typealias ReduxReducer<State> = (State, ReduxActionType) -> State
 
 /// Unique id for a subscriber.
-public typealias SubscriberId = String
+public typealias SubscriberId = UniqueIDProviderType.UniqueID
 
 /// Callback for state subscriptions.
 public typealias ReduxStateCallback<State> = (State) -> Void
@@ -35,16 +35,6 @@ public class NoopDispatcher {
 /// callback function.
 public typealias ReduxSubscriber<State> =
   (SubscriberId, @escaping ReduxStateCallback<State>) -> ReduxSubscription
-
-/// Subscription that can be unsubscribed from. This allows subscribers to
-/// store state to cancel anytime they want.
-public struct ReduxSubscription {
-  public let unsubscribe: () -> Void
-  
-  public init(_ unsubscribe: @escaping () -> Void) {
-    self.unsubscribe = unsubscribe
-  }
-}
 
 /// This store delegates all its functionalities to another store. It is used
 /// mainly for its type concreteness.

--- a/SwiftRedux/Core/Redux+Subscription.swift
+++ b/SwiftRedux/Core/Redux+Subscription.swift
@@ -1,0 +1,24 @@
+//
+//  Redux+Subscription.swift
+//  SwiftRedux
+//
+//  Created by Viethai Pham on 11/3/19.
+//  Copyright © 2019 Holmusk. All rights reserved.
+//
+
+/// Subscription that can be unsubscribed from. This allows subscribers to
+/// store state to cancel anytime they want.
+public struct ReduxSubscription {
+  /// No-op subscription that does not hold any logic.
+  public static let noop = ReduxSubscription(DefaultUniqueIDProvider.next(), {})
+  
+  public let uniqueID: UniqueID
+  public let unsubscribe: () -> Void
+  
+  public init(_ uniqueID: UniqueID, _ unsubscribe: @escaping () -> Void) {
+    self.uniqueID = uniqueID
+    self.unsubscribe = unsubscribe
+  }
+}
+
+extension ReduxSubscription: UniqueIDProviderType {}

--- a/SwiftRedux/Core/Redux+UniqueID.swift
+++ b/SwiftRedux/Core/Redux+UniqueID.swift
@@ -1,0 +1,26 @@
+//
+//  Redux+UniqueID.swift
+//  SwiftRedux
+//
+//  Created by Viethai Pham on 11/3/19.
+//  Copyright © 2019 Holmusk. All rights reserved.
+//
+
+import Foundation
+
+/// Utility class to automatically provide an ever-incrementing value. The
+/// increments are performed atomically.
+public class DefaultUniqueIDProvider {
+  
+  /// The current value.
+  private static var _current: Int64 = -1
+  
+  /// Get the next available unique ID.
+  ///
+  /// - Returns: A UniqueID instance.
+  static func next() -> UniqueIDProviderType.UniqueID {
+    return OSAtomicIncrement64(&self._current)
+  }
+  
+  init() {}
+}

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Output.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Output.swift
@@ -3,7 +3,7 @@
 //  SwiftRedux
 //
 //  Created by Viethai Pham on 11/3/19.
-//  Copyright © 2019 Holmusk. All rights reserved.
+//  Copyright © 2019 Hai Pham. All rights reserved.
 //
 
 import RxSwift

--- a/SwiftRedux/SimpleStore/Redux+SimpleStore.swift
+++ b/SwiftRedux/SimpleStore/Redux+SimpleStore.swift
@@ -26,7 +26,7 @@ public final class SimpleStore<State>: ReduxStoreType {
   private let _lock: ReadWriteLockType
   private var _state: State
   private let _reducer: ReduxReducer<State>
-  private var _subscribers: [String : ReduxStateCallback<State>]
+  private var _subscribers: [SubscriberId : ReduxStateCallback<State>]
   
   private init(_ initialState: State, _ reducer: @escaping ReduxReducer<State>) {
     self._lock = ReadWriteLock()
@@ -56,7 +56,7 @@ public final class SimpleStore<State>: ReduxStoreType {
     /// Broadcast the latest state to this subscriber.
     self._lock.access {cb(self._state)}
     
-    return ReduxSubscription {
+    return ReduxSubscription(id) {
       self._lock.modify {self._subscribers.removeValue(forKey: id)}
     }
   }

--- a/SwiftRedux/UI+Test/Redux+MockProps.swift
+++ b/SwiftRedux/UI+Test/Redux+MockProps.swift
@@ -15,6 +15,6 @@ public final class MockStaticProps<State>: StaticProps<State> {
 
   /// This initializer can be used to construct test static props.
   convenience public init(injector: PropInjector<State>) {
-    self.init(injector, ReduxSubscription({}))
+    self.init(injector, ReduxSubscription.noop)
   }
 }

--- a/SwiftRedux/UI/Redux+PropInjector.swift
+++ b/SwiftRedux/UI/Redux+PropInjector.swift
@@ -26,13 +26,6 @@ public class PropInjector<State>: PropInjectorType {
     CV.ReduxState == State
   {
     let dispatch = self.store.dispatch
-    
-    // Here we use the view's class name and a timestamp as the subscription
-    // id. We don't even need to store this id because we can simply cancel
-    // with the returned subscription callback (so the id can be literally
-    // anything, as long as it is unique).
-    let timestamp = Date().timeIntervalSince1970
-    let viewId = String(describing: cv) + String(describing: timestamp)
     var previous: CV.StateProps? = nil
     var first = true
     
@@ -69,7 +62,7 @@ public class PropInjector<State>: PropInjectorType {
     setProps(cv, self.store.lastState())
     
     let subscription = self.store
-      .subscribeState(viewId) {[weak cv] state in setProps(cv, state)}
+      .subscribeState(cv.uniqueID) {[weak cv] state in setProps(cv, state)}
     
     cv.staticProps = StaticProps(self, subscription)
     return subscription

--- a/SwiftRedux/UI/ReduxCompatibleView.swift
+++ b/SwiftRedux/UI/ReduxCompatibleView.swift
@@ -10,7 +10,7 @@ import UIKit
 
 /// A view that conforms to this protocol can receive state/action props and
 /// subscribe to state changes.
-public protocol ReduxCompatibleViewType: class {
+public protocol ReduxCompatibleViewType: class, UniqueIDProviderType {
 
   /// The app's global state type. This helps define the prop injector.
   associatedtype ReduxState

--- a/SwiftReduxTests/Redux+Subscription.swift
+++ b/SwiftReduxTests/Redux+Subscription.swift
@@ -1,0 +1,16 @@
+//
+//  Redux+Subscription.swift
+//  SwiftReduxTests
+//
+//  Created by Viethai Pham on 12/3/19.
+//  Copyright © 2019 Holmusk. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftRedux
+
+class ReduxSubscriptionTest: XCTestCase {
+  public func test_noopSubscription_shouldNotDoAnything() {
+    ReduxSubscription.noop.unsubscribe()
+  }
+}

--- a/SwiftReduxTests/Redux+UniqueID.swift
+++ b/SwiftReduxTests/Redux+UniqueID.swift
@@ -1,0 +1,39 @@
+//
+//  Redux+UniqueID.swift
+//  SwiftReduxTests
+//
+//  Created by Viethai Pham on 12/3/19.
+//  Copyright © 2019 Hai Pham. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftRedux
+
+public final class ReduxUniqueIDTests: XCTestCase {
+  override public func setUp() {
+    super.setUp()
+    _ = DefaultUniqueIDProvider()
+  }
+  
+  public func test_defaultUniqueIDProvider_shouldNotGiveDuplicates() {
+    /// Setup
+    let iterations = 10000
+    var generatedIDs = [UniqueIDProviderType.UniqueID]()
+    let semaphore = DispatchSemaphore(value: 1)
+    let dispatchGroup = DispatchGroup()
+    
+    (0...iterations).forEach({_ in dispatchGroup.enter()})
+    
+    /// When
+    (0...iterations).forEach({_ in DispatchQueue.global(qos: .background).async {
+      let uniqueID = DefaultUniqueIDProvider.next()
+      semaphore.wait()
+      defer { semaphore.signal(); dispatchGroup.leave() }
+      generatedIDs.append(uniqueID)
+    }})
+    
+    /// Then
+    dispatchGroup.wait()
+    XCTAssertEqual(generatedIDs.sorted(), (0...iterations).map(Int64.init))
+  }
+}

--- a/SwiftReduxTests/Redux+UniqueID.swift
+++ b/SwiftReduxTests/Redux+UniqueID.swift
@@ -34,6 +34,6 @@ public final class ReduxUniqueIDTests: XCTestCase {
     
     /// Then
     dispatchGroup.wait()
-    XCTAssertEqual(generatedIDs.sorted(), (0...iterations).map(Int64.init))
+    XCTAssertEqual(Set(generatedIDs).count, generatedIDs.count)
   }
 }

--- a/SwiftReduxTests/ReduxMiddlewareTest.swift
+++ b/SwiftReduxTests/ReduxMiddlewareTest.swift
@@ -52,7 +52,8 @@ extension ReduxMiddlewareTest {
     
     let wrapper = combineMiddlewares(middlewares)(self.store)
     let newStore = applyMiddlewares(middlewares)(self.store)
-    let subscription = newStore.subscribeState("", {subscribedValue = $0.a})
+    let subID = DefaultUniqueIDProvider.next()
+    let subscription = newStore.subscribeState(subID, {subscribedValue = $0.a})
     
     /// When
     _ = newStore.dispatch(DefaultAction.noop)

--- a/SwiftReduxTests/ReduxStoreTest.swift
+++ b/SwiftReduxTests/ReduxStoreTest.swift
@@ -96,8 +96,9 @@ extension ReduxStoreTest {
   {
     /// Setup
     let iterations = 100
+    let subID = DefaultUniqueIDProvider.next()
     var callbackCount = 0
-    let subscription = store.subscribeState("", {_ in callbackCount += 1})
+    let subscription = store.subscribeState(subID, {_ in callbackCount += 1})
     
     /// When
     (0..<iterations).forEach({_ in _ = store.dispatch(Action.add)})

--- a/SwiftReduxTests/ReduxUITest.swift
+++ b/SwiftReduxTests/ReduxUITest.swift
@@ -151,7 +151,7 @@ extension ReduxUITests {
       }
     }
     
-    private var subscribers = [String : ReduxStateCallback<State>]()
+    private var subscribers = [SubscriberId : ReduxStateCallback<State>]()
     var unsubscribeCount: Int = 0
     
     init() {
@@ -165,14 +165,13 @@ extension ReduxUITests {
     var dispatch = NoopDispatcher.instance
     
     var subscribeState: ReduxSubscriber<State> {
-      return {
-        let subscriberId = $0
-        self.subscribers[subscriberId] = $1
+      return {subscriberID, callback in
+        self.subscribers[subscriberID] = callback
       
-        return ReduxSubscription({
+        return ReduxSubscription(subscriberID) {
           self.unsubscribeCount += 1
-          self.subscribers.removeValue(forKey: subscriberId)
-        })
+          self.subscribers.removeValue(forKey: subscriberID)
+        }
       }
     }
   }
@@ -181,7 +180,7 @@ extension ReduxUITests {
 extension ReduxUITests {
   final class ViewController: UIViewController {
     deinit { self.onDeinit?() }
-    
+    let uniqueID = DefaultUniqueIDProvider.next()
     var staticProps: StaticProps<State>?
     
     var variableProps: VariableProps<StateProps, ActionProps>? {
@@ -199,7 +198,7 @@ extension ReduxUITests {
   
   final class View: UIView {
     deinit { self.onDeinit?() }
-    
+    let uniqueID = DefaultUniqueIDProvider.next()
     var staticProps: StaticProps<State>?
     
     var variableProps: VariableProps<StateProps, ActionProps>? {


### PR DESCRIPTION
Add `UniqueIDProviderType` and `DefaultUniqueIDProvider` to provide all-purpose unique IDs:

```swift
let uniqueID = DefaultUniqueIDProvider.next()
```

This unique ID is used for `ReduxSubscription` and `ReduxCompatibleViewType`, and will serve other purposes as we add more features.