### PR TITLE
Add unsubscribe functionality to stores

### DIFF
--- a/SwiftRedux.xcodeproj/project.pbxproj
+++ b/SwiftRedux.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		D3300E1121B3713E00779B7F /* ReduxMiddlewareTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3300E1021B3713E00779B7F /* ReduxMiddlewareTest.swift */; };
 		D334ED5F21B773CA004C538E /* ReduxSagaTest+Effect.swift in Sources */ = {isa = PBXBuildFile; fileRef = D334ED5E21B773CA004C538E /* ReduxSagaTest+Effect.swift */; };
 		D335E28F21B6E689000E664D /* ReduxSagaTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D335E28E21B6E689000E664D /* ReduxSagaTest.swift */; };
-		D350C3591FA345200040556F /* ReduxStoreTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D350C3581FA345200040556F /* ReduxStoreTest.swift */; };
+		D350C3591FA345200040556F /* Redux+Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = D350C3581FA345200040556F /* Redux+Store.swift */; };
 		D352CE60205CB3C800319B07 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = D352CE5F205CB3C800319B07 /* README.md */; };
 		D3803C6521B3E4EB0055467D /* ReduxRouterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3803C6421B3E4EB0055467D /* ReduxRouterTest.swift */; };
 		D3810F5921C0CA550058FA86 /* ReduxLockTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3810F5821C0CA550058FA86 /* ReduxLockTest.swift */; };
@@ -124,7 +124,7 @@
 		D3300E1021B3713E00779B7F /* ReduxMiddlewareTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReduxMiddlewareTest.swift; sourceTree = "<group>"; };
 		D334ED5E21B773CA004C538E /* ReduxSagaTest+Effect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReduxSagaTest+Effect.swift"; sourceTree = "<group>"; };
 		D335E28E21B6E689000E664D /* ReduxSagaTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReduxSagaTest.swift; sourceTree = "<group>"; };
-		D350C3581FA345200040556F /* ReduxStoreTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReduxStoreTest.swift; sourceTree = "<group>"; };
+		D350C3581FA345200040556F /* Redux+Store.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+Store.swift"; sourceTree = "<group>"; };
 		D350C3621FA388190040556F /* SwiftRedux-Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SwiftRedux-Demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D352CE5F205CB3C800319B07 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		D3803C6421B3E4EB0055467D /* ReduxRouterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReduxRouterTest.swift; sourceTree = "<group>"; };
@@ -304,7 +304,7 @@
 				D3803C6421B3E4EB0055467D /* ReduxRouterTest.swift */,
 				D335E28E21B6E689000E664D /* ReduxSagaTest.swift */,
 				D334ED5E21B773CA004C538E /* ReduxSagaTest+Effect.swift */,
-				D350C3581FA345200040556F /* ReduxStoreTest.swift */,
+				D350C3581FA345200040556F /* Redux+Store.swift */,
 				D30DBF9C21AD8E2900CD1233 /* ReduxUITest.swift */,
 			);
 			path = SwiftReduxTests;
@@ -806,7 +806,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D3803C6521B3E4EB0055467D /* ReduxRouterTest.swift in Sources */,
-				D350C3591FA345200040556F /* ReduxStoreTest.swift in Sources */,
+				D350C3591FA345200040556F /* Redux+Store.swift in Sources */,
 				D30DBF9D21AD8E2900CD1233 /* ReduxUITest.swift in Sources */,
 				D335E28F21B6E689000E664D /* ReduxSagaTest.swift in Sources */,
 				D30CC2FF205C40F0005B5EA1 /* ReduxPresetTest.swift in Sources */,

--- a/SwiftRedux/Core/Protocols.swift
+++ b/SwiftRedux/Core/Protocols.swift
@@ -17,7 +17,7 @@ public protocol ReduxActionType {}
 
 /// This represents a Redux store that can dispatch actions to mutate internal
 /// state and broadcast state updates to subscribers.
-public protocol ReduxStoreType {
+public protocol ReduxStoreType: ReduxUnsubscriberProviderType {
   
   /// The app-specific state type. For example:
   ///

--- a/SwiftRedux/Middleware/Redux+EnhancedStore.swift
+++ b/SwiftRedux/Middleware/Redux+EnhancedStore.swift
@@ -22,6 +22,10 @@ struct EnhancedStore<State> {
 }
 
 extension EnhancedStore: ReduxStoreType {
+  public var dispatch: ReduxDispatcher {
+    return self._dispatch
+  }
+  
   public var lastState: ReduxStateGetter<State> {
     return self._store.lastState
   }
@@ -30,7 +34,7 @@ extension EnhancedStore: ReduxStoreType {
     return self._store.subscribeState
   }
   
-  public var dispatch: ReduxDispatcher {
-    return self._dispatch
+  public var unsubscribe: ReduxUnsubscriber {
+    return self._store.unsubscribe
   }
 }

--- a/SwiftRedux/SimpleStore/Redux+SimpleStore.swift
+++ b/SwiftRedux/SimpleStore/Redux+SimpleStore.swift
@@ -26,7 +26,7 @@ public final class SimpleStore<State>: ReduxStoreType {
   private let _lock: ReadWriteLockType
   private var _state: State
   private let _reducer: ReduxReducer<State>
-  private var _subscribers: [SubscriberId : ReduxStateCallback<State>]
+  private var _subscribers: [SubscriberID : ReduxStateCallback<State>]
   
   private init(_ initialState: State, _ reducer: @escaping ReduxReducer<State>) {
     self._lock = ReadWriteLock()
@@ -55,9 +55,10 @@ public final class SimpleStore<State>: ReduxStoreType {
     
     /// Broadcast the latest state to this subscriber.
     self._lock.access {cb(self._state)}
-    
-    return ReduxSubscription(id) {
-      self._lock.modify {self._subscribers.removeValue(forKey: id)}
-    }
+    return ReduxSubscription(id) {self.unsubscribe(id)}
+  }
+  
+  public lazy private(set) var unsubscribe: ReduxUnsubscriber = {id in
+    self._lock.modify {self._subscribers.removeValue(forKey: id)}
   }
 }

--- a/SwiftRedux/UI+Test/Redux+MockInjector.swift
+++ b/SwiftRedux/UI+Test/Redux+MockInjector.swift
@@ -33,7 +33,8 @@ public final class MockInjector<State>: PropInjector<State> {
     let store: DelegateStore<State> = .init(
       {fatalError()},
       {_ in fatalError()},
-      {_,_ in fatalError()}
+      {_,_ in fatalError()},
+      {_ in fatalError()}
     )
     
     self.init(store: store)

--- a/SwiftReduxTests/ReduxUITest.swift
+++ b/SwiftReduxTests/ReduxUITest.swift
@@ -151,7 +151,7 @@ extension ReduxUITests {
       }
     }
     
-    private var subscribers = [SubscriberId : ReduxStateCallback<State>]()
+    private var subscribers = [SubscriberID : ReduxStateCallback<State>]()
     var unsubscribeCount: Int = 0
     
     init() {
@@ -173,6 +173,10 @@ extension ReduxUITests {
           self.subscribers.removeValue(forKey: subscriberID)
         }
       }
+    }
+    
+    var unsubscribe: ReduxUnsubscriber {
+      return {self.subscribers.removeValue(forKey: $0)}
     }
   }
 }


### PR DESCRIPTION
Redux store can now unsubscribe a subscription manually using a subscriber ID:

```swift
store.unsubscribe(id)
```

This will be useful for store wrappers that also want to implement their own subscription logic, but do not want to keep track of all the internal store's subscriptions to call `subscription.unsubscribe`.