### PR TITLE
Simpler prop injector

### DIFF
--- a/SwiftRedux/UI+Test/Redux+MockInjector.swift
+++ b/SwiftRedux/UI+Test/Redux+MockInjector.swift
@@ -48,34 +48,17 @@ public final class MockInjector<State>: PropInjector<State> {
   /// Add one count to the view controller injectee.
   ///
   /// - Parameters:
-  ///   - vc: A view controller instance.
+  ///   - cv: A Redux-compatible view.
   ///   - outProps: An OutProps instance.
   ///   - mapper: A Redux prop mapper.
-  override public func injectProps<VC, MP>(
-    controller: VC, outProps: VC.OutProps, mapper: MP.Type) where
+  public override func injectProps<CV, MP>(_ cv: CV, _ op: CV.OutProps, _ mapper: MP.Type)
+    -> ReduxSubscription where
     MP: PropMapperType,
-    MP.ReduxView == VC,
-    VC: UIViewController,
-    VC.ReduxState == State
+    MP.ReduxView == CV,
+    CV.ReduxState == State
   {
-    self.addInjecteeCount(controller)
-  }
-  
-  /// Add one count to the view injectee.
-  ///
-  /// - Parameters:
-  ///   - view: A view instance.
-  ///   - outProps: An OutProps instance.
-  ///   - mapper: A Redux prop mapper.
-  /// - Returns: A ReduxSubscription instance.
-  override public func injectProps<V, MP>(
-    view: V, outProps: V.OutProps, mapper: MP.Type) where
-    MP: PropMapperType,
-    MP.ReduxView == V,
-    V: UIView,
-    V.ReduxState == State
-  {
-    self.addInjecteeCount(view)
+    self.addInjecteeCount(cv)
+    return ReduxSubscription.noop
   }
   
   /// Check if a Redux view has been injected as many times as specified.

--- a/SwiftRedux/UI/Redux+PropInjector.swift
+++ b/SwiftRedux/UI/Redux+PropInjector.swift
@@ -22,7 +22,7 @@ public class PropInjector<State>: PropInjectorType {
     self.runner = runner
   }
   
-  func _inject<CV, MP>(_ cv: CV, _ op: CV.OutProps, _ mapper: MP.Type)
+  public func injectProps<CV, MP>(_ cv: CV, _ op: CV.OutProps, _ mapper: MP.Type)
     -> ReduxSubscription where
     MP: PropMapperType,
     MP.ReduxView == CV,
@@ -69,43 +69,5 @@ public class PropInjector<State>: PropInjectorType {
     
     cv.staticProps = StaticProps(self, subscription)
     return subscription
-  }
-  
-  public func injectProps<VC, MP>(
-    controller: VC, outProps: VC.OutProps, mapper: MP.Type) where
-    MP: PropMapperType,
-    MP.ReduxView == VC,
-    VC: UIViewController,
-    VC.ReduxState == State
-  {
-    let subscription = self._inject(controller, outProps, mapper)
-    let lifecycleVC = LifecycleViewController()
-    lifecycleVC.onDeinit = subscription.unsubscribe
-    controller.addChild(lifecycleVC)
-  }
-  
-  public func injectProps<V, MP>(
-    view: V, outProps: V.OutProps, mapper: MP.Type) where
-    MP: PropMapperType,
-    MP.ReduxView == V,
-    V: UIView,
-    V.ReduxState == State
-  {
-    let subscription = self._inject(view, outProps, mapper)
-    let lifecycleView = LifecycleView()
-    lifecycleView.onDeinit = subscription.unsubscribe
-    view.addSubview(lifecycleView)
-  }
-}
-
-extension PropInjector {
-  final class LifecycleViewController: UIViewController {
-    deinit { self.onDeinit?() }
-    var onDeinit: (() -> Void)?
-  }
-  
-  final class LifecycleView: UIView {
-    deinit { self.onDeinit?() }
-    var onDeinit: (() -> Void)?
   }
 }

--- a/SwiftRedux/UI/ReduxPropInjector.swift
+++ b/SwiftRedux/UI/ReduxPropInjector.swift
@@ -15,17 +15,39 @@ public protocol PropInjectorType {
   /// The app-specific state type.
   associatedtype State
   
+  /// Inject state/action props into a compatible prop container.
+  ///
+  /// - Parameters:
+  ///   - cv: A Redux-compatible view.
+  ///   - outProps: An OutProps instance.
+  ///   - mapper: A Redux prop mapper.
+  func injectProps<CV, MP>(_ cv: CV, _ outProps: CV.OutProps, _ mapper: MP.Type)
+    -> ReduxSubscription where
+    MP: PropMapperType,
+    MP.ReduxView == CV,
+    CV.ReduxState == State
+}
+
+public extension PropInjectorType {
+  
   /// Inject state/action props into a compatible view controller.
   ///
   /// - Parameters:
   ///   - vc: A view controller instance.
   ///   - outProps: An OutProps instance.
   ///   - mapper: A Redux prop mapper.
-  func injectProps<VC, MP>(controller: VC, outProps: VC.OutProps, mapper: MP.Type) where
+  public func injectProps<VC, MP>(
+    controller: VC, outProps: VC.OutProps, mapper: MP.Type) where
     MP: PropMapperType,
     MP.ReduxView == VC,
     VC: UIViewController,
     VC.ReduxState == State
+  {
+    let subscription = self.injectProps(controller, outProps, mapper)
+    let lifecycleVC = LifecycleViewController()
+    lifecycleVC.onDeinit = subscription.unsubscribe
+    controller.addChild(lifecycleVC)
+  }
   
   /// Inject state/action props into a compatible view.
   ///
@@ -34,14 +56,18 @@ public protocol PropInjectorType {
   ///   - outProps: An OutProps instance.
   ///   - mapper: A Redux prop mapper.
   /// - Returns: A ReduxSubscription instance.
-  func injectProps<V, MP>(view: V, outProps: V.OutProps, mapper: MP.Type) where
+  public func injectProps<V, MP>(
+    view: V, outProps: V.OutProps, mapper: MP.Type) where
     MP: PropMapperType,
     MP.ReduxView == V,
     V: UIView,
     V.ReduxState == State
-}
-
-public extension PropInjectorType {
+  {
+    let subscription = self.injectProps(view, outProps, mapper)
+    let lifecycleView = LifecycleView()
+    lifecycleView.onDeinit = subscription.unsubscribe
+    view.addSubview(lifecycleView)
+  }
   
   /// Convenience method to inject props when the controller also conforms to
   /// the necessary protocols.
@@ -74,4 +100,14 @@ public extension PropInjectorType {
   {
     self.injectProps(view: view, outProps: outProps, mapper: V.self)
   }
+}
+
+final class LifecycleViewController: UIViewController {
+  deinit { self.onDeinit?() }
+  var onDeinit: (() -> Void)?
+}
+
+final class LifecycleView: UIView {
+  deinit { self.onDeinit?() }
+  var onDeinit: (() -> Void)?
 }


### PR DESCRIPTION
Move view controller and view injection methods to extension, allow prop injectors implement only one method:

```swift
public protocol PropInjectorType {
  /// The app-specific state type.
  associatedtype State
  
  func injectProps<CV, MP>(_ cv: CV, _ outProps: CV.OutProps, _ mapper: MP.Type)
    -> ReduxSubscription where
    MP: PropMapperType,
    MP.ReduxView == CV,
    CV.ReduxState == State
}
```

This used to be private in the default prop injector, but it is more useful for testing as a standalone method.