### PR TITLE
Simpler redux props

### DIFF
--- a/SwiftRedux-Demo/ConfirmButton.swift
+++ b/SwiftRedux-Demo/ConfirmButton.swift
@@ -13,7 +13,7 @@ import UIKit
 final class ConfirmButton: UIButton {
   let uniqueID = DefaultUniqueIDProvider.next()
   var staticProps: Static?
-  var variableProps: Variables?
+  var reduxProps: ReduxProps<StateProps, ActionProps>?
   
   override func awakeFromNib() {
     super.awakeFromNib()
@@ -21,7 +21,7 @@ final class ConfirmButton: UIButton {
   }
   
   @objc func onClick(_ sender: UIButton) {
-    self.variableProps?.action.confirmEdit()
+    self.reduxProps?.action.confirmEdit()
   }
 }
 

--- a/SwiftRedux-Demo/ConfirmButton.swift
+++ b/SwiftRedux-Demo/ConfirmButton.swift
@@ -12,8 +12,8 @@ import UIKit
 
 final class ConfirmButton: UIButton {
   let uniqueID = DefaultUniqueIDProvider.next()
-  var staticProps: Static?
-  var reduxProps: ReduxProps<StateProps, ActionProps>?
+  var staticProps: StaticProps!
+  var reduxProps: ReduxProps?
   
   override func awakeFromNib() {
     super.awakeFromNib()
@@ -21,13 +21,12 @@ final class ConfirmButton: UIButton {
   }
   
   @objc func onClick(_ sender: UIButton) {
-    self.reduxProps?.action.confirmEdit()
+    self.requireReduxProps().action.confirmEdit()
   }
 }
 
 extension ConfirmButton: PropContainerType {
   typealias OutProps = ()
-  
   struct StateProps: Equatable {}
   
   struct ActionProps {

--- a/SwiftRedux-Demo/Redux+Mapper.swift
+++ b/SwiftRedux-Demo/Redux+Mapper.swift
@@ -24,7 +24,7 @@ extension RootController: PropMapperType {
     )
   }
   
-  static func compareState(lhs: StateProps?, rhs: StateProps?) -> Bool {
+  static func compareState(_ lhs: StateProps?, _ rhs: StateProps?) -> Bool {
     return true
   }
 }

--- a/SwiftRedux-Demo/RootController.swift
+++ b/SwiftRedux-Demo/RootController.swift
@@ -13,16 +13,17 @@ final class RootController: UIViewController {
   @IBOutlet private weak var viewController1: UIButton!
   
   let uniqueID = DefaultUniqueIDProvider.next()
-  var staticProps: Static?
-  var reduxProps: ReduxProps<(), ActionProps>?
+  var staticProps: StaticProps!
+  var reduxProps: ReduxProps?
   
   @IBAction func goToViewController1(_ sender: UIButton) {
-    self.reduxProps?.action.goToViewController1()
+    self.requireReduxProps().action.goToViewController1()
   }
 }
 
 extension RootController: PropContainerType {
   typealias OutProps = ()
+  typealias StateProps = ()
   
   struct ActionProps {
     let goToViewController1: () -> Void

--- a/SwiftRedux-Demo/RootController.swift
+++ b/SwiftRedux-Demo/RootController.swift
@@ -14,16 +14,15 @@ final class RootController: UIViewController {
   
   let uniqueID = DefaultUniqueIDProvider.next()
   var staticProps: Static?
-  var variableProps: Variables?
+  var reduxProps: ReduxProps<(), ActionProps>?
   
   @IBAction func goToViewController1(_ sender: UIButton) {
-    self.variableProps?.action.goToViewController1()
+    self.reduxProps?.action.goToViewController1()
   }
 }
 
 extension RootController: PropContainerType {
   typealias OutProps = ()
-  typealias StateProps = ()
   
   struct ActionProps {
     let goToViewController1: () -> Void

--- a/SwiftRedux-Demo/TableCell.swift
+++ b/SwiftRedux-Demo/TableCell.swift
@@ -19,7 +19,7 @@ final class TableCell: UITableViewCell {
   var variableProps: Variables? {
     didSet {
       if let props = self.variableProps {
-        textInput.text = props.nextState.text
+        textInput.text = props.state.text
       }
     }
   }

--- a/SwiftRedux-Demo/TableCell.swift
+++ b/SwiftRedux-Demo/TableCell.swift
@@ -16,16 +16,16 @@ final class TableCell: UITableViewCell {
   let uniqueID = DefaultUniqueIDProvider.next()
   var staticProps: Static?
   
-  var variableProps: Variables? {
+  var reduxProps: ReduxProps<StateProps, ActionProps>? {
     didSet {
-      if let props = self.variableProps {
+      if let props = self.reduxProps {
         textInput.text = props.state.text
       }
     }
   }
   
   @IBAction func updateText(_ sender: UITextField) {
-    self.variableProps?.action.updateText(sender.text)
+    self.reduxProps?.action.updateText(sender.text)
   }
 }
 

--- a/SwiftRedux-Demo/TableCell.swift
+++ b/SwiftRedux-Demo/TableCell.swift
@@ -14,9 +14,9 @@ final class TableCell: UITableViewCell {
   
   var textIndex: Int?
   let uniqueID = DefaultUniqueIDProvider.next()
-  var staticProps: Static?
+  var staticProps: StaticProps!
   
-  var reduxProps: ReduxProps<StateProps, ActionProps>? {
+  var reduxProps: ReduxProps? {
     didSet {
       if let props = self.reduxProps {
         textInput.text = props.state.text
@@ -25,7 +25,7 @@ final class TableCell: UITableViewCell {
   }
   
   @IBAction func updateText(_ sender: UITextField) {
-    self.reduxProps?.action.updateText(sender.text)
+    self.requireReduxProps().action.updateText(sender.text)
   }
 }
 

--- a/SwiftRedux-Demo/ViewController1.swift
+++ b/SwiftRedux-Demo/ViewController1.swift
@@ -23,13 +23,13 @@ final class ViewController1: UIViewController {
   
   let uniqueID = DefaultUniqueIDProvider.next()
   
-  public var staticProps: Static? {
+  public var staticProps: StaticProps! {
     didSet {
       self.staticProps?.injector.injectProps(view: self.clearButton, outProps: ())
     }
   }
   
-  public var reduxProps: ReduxProps<StateProps, ActionProps>? {
+  public var reduxProps: ReduxProps? {
     didSet {
       guard let props = self.reduxProps else { return }
       let nextState = props.state
@@ -67,6 +67,7 @@ final class ViewController1: UIViewController {
 
   override public func viewDidLoad() {
     super.viewDidLoad()
+    print("Did load")
     self.counterTF.isEnabled = false
     self.stringTF1.isEnabled = false
     self.slideTF.isEnabled = false
@@ -86,27 +87,27 @@ final class ViewController1: UIViewController {
   }
   
   @IBAction func incrementNumber(_ sender: UIButton) {
-    self.reduxProps?.action.incrementNumber()
+    self.requireReduxProps().action.incrementNumber()
   }
   
   @IBAction func decrementNumber(_ sender: UIButton) {
-    self.reduxProps?.action.decrementNumber()
+    self.requireReduxProps().action.decrementNumber()
   }
   
   @IBAction func updateString(_ sender: UITextField) {
-    self.reduxProps?.action.updateString(sender.text)
+    self.requireReduxProps().action.updateString(sender.text)
   }
   
   @IBAction func updateSlider(_ sender: UISlider) {
-    self.reduxProps?.action.updateSlider(Double(sender.value))
+    self.requireReduxProps().action.updateSlider(Double(sender.value))
   }
   
   @IBAction func addTextItem(_ sender: UIButton) {
-    self.reduxProps?.action.addOneText()
+    self.requireReduxProps().action.addOneText()
   }
   
   @objc func goBack(_ sender: UIBarButtonItem) {
-    self.reduxProps?.action.goBack()
+    self.requireReduxProps().action.goBack()
   }
   
   @objc func reloadTable(_ sender: UIBarButtonItem) {
@@ -125,8 +126,8 @@ extension ViewController1: UITableViewDataSource {
     let cell = tableView
       .dequeueReusableCell(withIdentifier: "TableCell") as! TableCell
 
-    let textIndex = self.reduxProps?.state.textIndexes?[indexPath.row]
-    cell.textIndex = self.reduxProps?.state.textIndexes?[indexPath.row]
+    let textIndex = self.requireReduxProps().state.textIndexes?[indexPath.row]
+    cell.textIndex = self.requireReduxProps().state.textIndexes?[indexPath.row]
     _ = self.staticProps?.injector.injectProps(view: cell, outProps: textIndex!)
     return cell
   }
@@ -141,7 +142,7 @@ extension ViewController1: UITableViewDataSource {
                  forRowAt indexPath: IndexPath) {
     switch editingStyle {
     case .delete:
-      self.reduxProps?.action.deleteText(indexPath.row)
+      self.requireReduxProps().action.deleteText(indexPath.row)
       
     default:
       break

--- a/SwiftRedux-Demo/ViewController1.swift
+++ b/SwiftRedux-Demo/ViewController1.swift
@@ -32,22 +32,22 @@ final class ViewController1: UIViewController {
   public var variableProps: Variables? {
     didSet {
       guard let props = self.variableProps else { return }
-      let nextState = props.nextState
-      self.counterTF.text = props.nextState.number.map(String.init)
-      self.slideTF.text = props.nextState.slider.map(String.init)
-      self.stringTF1.text = props.nextState.string
-      self.stringTF2.text = props.nextState.string
-      self.valueSL.value = props.nextState.slider ?? valueSL.minimumValue
+      let nextState = props.state
+      self.counterTF.text = props.state.number.map(String.init)
+      self.slideTF.text = props.state.slider.map(String.init)
+      self.stringTF1.text = props.state.string
+      self.stringTF2.text = props.state.string
+      self.valueSL.value = props.state.slider ?? valueSL.minimumValue
       
-      if props.nextState.progress.getOrElse(false) {
-        if props.nextState.progress != props.previousState?.progress {
+      if props.state.progress.getOrElse(false) {
+        if props.state.progress != oldValue?.state.progress {
           MRProgressOverlayView.showOverlayAdded(to: self.view, animated: true)
         }
       } else {
         MRProgressOverlayView.dismissOverlay(for: self.view, animated: true)
       }
       
-      let prevIndexes = props.previousState?.textIndexes ?? []
+      let prevIndexes = oldValue?.state.textIndexes ?? []
       let nextIndexes = nextState.textIndexes ?? []
       let prevSet = Set(prevIndexes.enumerated().map({[$0, $1]}))
       let nextSet = Set(nextIndexes.enumerated().map({[$0, $1]}))
@@ -117,7 +117,7 @@ final class ViewController1: UIViewController {
 extension ViewController1: UITableViewDataSource {
   func tableView(_ tableView: UITableView,
                  numberOfRowsInSection section: Int) -> Int {
-    return self.variableProps?.nextState.textIndexes?.count ?? 0
+    return self.variableProps?.state.textIndexes?.count ?? 0
   }
   
   func tableView(_ tableView: UITableView,
@@ -125,8 +125,8 @@ extension ViewController1: UITableViewDataSource {
     let cell = tableView
       .dequeueReusableCell(withIdentifier: "TableCell") as! TableCell
 
-    let textIndex = self.variableProps?.nextState.textIndexes?[indexPath.row]
-    cell.textIndex = self.variableProps?.nextState.textIndexes?[indexPath.row]
+    let textIndex = self.variableProps?.state.textIndexes?[indexPath.row]
+    cell.textIndex = self.variableProps?.state.textIndexes?[indexPath.row]
     _ = self.staticProps?.injector.injectProps(view: cell, outProps: textIndex!)
     return cell
   }

--- a/SwiftRedux-Demo/ViewController1.swift
+++ b/SwiftRedux-Demo/ViewController1.swift
@@ -29,9 +29,9 @@ final class ViewController1: UIViewController {
     }
   }
   
-  public var variableProps: Variables? {
+  public var reduxProps: ReduxProps<StateProps, ActionProps>? {
     didSet {
-      guard let props = self.variableProps else { return }
+      guard let props = self.reduxProps else { return }
       let nextState = props.state
       self.counterTF.text = props.state.number.map(String.init)
       self.slideTF.text = props.state.slider.map(String.init)
@@ -86,27 +86,27 @@ final class ViewController1: UIViewController {
   }
   
   @IBAction func incrementNumber(_ sender: UIButton) {
-    self.variableProps?.action.incrementNumber()
+    self.reduxProps?.action.incrementNumber()
   }
   
   @IBAction func decrementNumber(_ sender: UIButton) {
-    self.variableProps?.action.decrementNumber()
+    self.reduxProps?.action.decrementNumber()
   }
   
   @IBAction func updateString(_ sender: UITextField) {
-    self.variableProps?.action.updateString(sender.text)
+    self.reduxProps?.action.updateString(sender.text)
   }
   
   @IBAction func updateSlider(_ sender: UISlider) {
-    self.variableProps?.action.updateSlider(Double(sender.value))
+    self.reduxProps?.action.updateSlider(Double(sender.value))
   }
   
   @IBAction func addTextItem(_ sender: UIButton) {
-    self.variableProps?.action.addOneText()
+    self.reduxProps?.action.addOneText()
   }
   
   @objc func goBack(_ sender: UIBarButtonItem) {
-    self.variableProps?.action.goBack()
+    self.reduxProps?.action.goBack()
   }
   
   @objc func reloadTable(_ sender: UIBarButtonItem) {
@@ -117,7 +117,7 @@ final class ViewController1: UIViewController {
 extension ViewController1: UITableViewDataSource {
   func tableView(_ tableView: UITableView,
                  numberOfRowsInSection section: Int) -> Int {
-    return self.variableProps?.state.textIndexes?.count ?? 0
+    return self.reduxProps?.state.textIndexes?.count ?? 0
   }
   
   func tableView(_ tableView: UITableView,
@@ -125,8 +125,8 @@ extension ViewController1: UITableViewDataSource {
     let cell = tableView
       .dequeueReusableCell(withIdentifier: "TableCell") as! TableCell
 
-    let textIndex = self.variableProps?.state.textIndexes?[indexPath.row]
-    cell.textIndex = self.variableProps?.state.textIndexes?[indexPath.row]
+    let textIndex = self.reduxProps?.state.textIndexes?[indexPath.row]
+    cell.textIndex = self.reduxProps?.state.textIndexes?[indexPath.row]
     _ = self.staticProps?.injector.injectProps(view: cell, outProps: textIndex!)
     return cell
   }
@@ -141,7 +141,7 @@ extension ViewController1: UITableViewDataSource {
                  forRowAt indexPath: IndexPath) {
     switch editingStyle {
     case .delete:
-      self.variableProps?.action.deleteText(indexPath.row)
+      self.reduxProps?.action.deleteText(indexPath.row)
       
     default:
       break

--- a/SwiftRedux.xcodeproj/project.pbxproj
+++ b/SwiftRedux.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		C19A24D322455F087422BE9C /* Pods_SwiftReduxTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92BE97133E8C5159CE105583 /* Pods_SwiftReduxTests.framework */; };
 		D30CC2FF205C40F0005B5EA1 /* ReduxPresetTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30CC2FE205C40F0005B5EA1 /* ReduxPresetTest.swift */; };
-		D30DBF9D21AD8E2900CD1233 /* ReduxUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30DBF9C21AD8E2900CD1233 /* ReduxUITest.swift */; };
+		D30DBF9D21AD8E2900CD1233 /* Redux+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30DBF9C21AD8E2900CD1233 /* Redux+UI.swift */; };
 		D3300E1121B3713E00779B7F /* ReduxMiddlewareTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3300E1021B3713E00779B7F /* ReduxMiddlewareTest.swift */; };
 		D334ED5F21B773CA004C538E /* ReduxSagaTest+Effect.swift in Sources */ = {isa = PBXBuildFile; fileRef = D334ED5E21B773CA004C538E /* ReduxSagaTest+Effect.swift */; };
 		D335E28F21B6E689000E664D /* ReduxSagaTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D335E28E21B6E689000E664D /* ReduxSagaTest.swift */; };
@@ -74,6 +74,7 @@
 		EE567CF22236BF5200E907F4 /* Redux+UniqueID.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE567CF12236BF5200E907F4 /* Redux+UniqueID.swift */; };
 		EE567CF42236C2C600E907F4 /* Redux+Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE567CF32236C2C600E907F4 /* Redux+Subscription.swift */; };
 		EE567CF62236C94A00E907F4 /* Redux+Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE567CF52236C94A00E907F4 /* Redux+Subscription.swift */; };
+		EE57167D223F2A23009B8D87 /* Redux+UI+Integration.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57167C223F2A23009B8D87 /* Redux+UI+Integration.swift */; };
 		EE7111D52235474B00532177 /* Redux+Core.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7111D42235474B00532177 /* Redux+Core.swift */; };
 		EE7111DB2235756400532177 /* Redux+Saga+Output.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7111DA2235756300532177 /* Redux+Saga+Output.swift */; };
 		EEC1DE83223DE98300E4AF43 /* Redux+MainThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC1DE82223DE98300E4AF43 /* Redux+MainThread.swift */; };
@@ -121,7 +122,7 @@
 		B9EDBA54900509BCC49BFB00 /* Pods_SwiftRedux_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftRedux_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C36C772AA7FE61280A9F9EA9 /* Pods-SwiftRedux-Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftRedux-Demo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftRedux-Demo/Pods-SwiftRedux-Demo.debug.xcconfig"; sourceTree = "<group>"; };
 		D30CC2FE205C40F0005B5EA1 /* ReduxPresetTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReduxPresetTest.swift; sourceTree = "<group>"; };
-		D30DBF9C21AD8E2900CD1233 /* ReduxUITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReduxUITest.swift; sourceTree = "<group>"; };
+		D30DBF9C21AD8E2900CD1233 /* Redux+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+UI.swift"; sourceTree = "<group>"; };
 		D3300E1021B3713E00779B7F /* ReduxMiddlewareTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReduxMiddlewareTest.swift; sourceTree = "<group>"; };
 		D334ED5E21B773CA004C538E /* ReduxSagaTest+Effect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReduxSagaTest+Effect.swift"; sourceTree = "<group>"; };
 		D335E28E21B6E689000E664D /* ReduxSagaTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReduxSagaTest.swift; sourceTree = "<group>"; };
@@ -138,6 +139,7 @@
 		EE567CF12236BF5200E907F4 /* Redux+UniqueID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Redux+UniqueID.swift"; sourceTree = "<group>"; };
 		EE567CF32236C2C600E907F4 /* Redux+Subscription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Redux+Subscription.swift"; sourceTree = "<group>"; };
 		EE567CF52236C94A00E907F4 /* Redux+Subscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+Subscription.swift"; sourceTree = "<group>"; };
+		EE57167C223F2A23009B8D87 /* Redux+UI+Integration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+UI+Integration.swift"; sourceTree = "<group>"; };
 		EE7111D42235474B00532177 /* Redux+Core.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+Core.swift"; sourceTree = "<group>"; };
 		EE7111DA2235756300532177 /* Redux+Saga+Output.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Redux+Saga+Output.swift"; sourceTree = "<group>"; };
 		EEAABD0B221D174500543DE2 /* Redux+SimpleStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+SimpleStore.swift"; sourceTree = "<group>"; };
@@ -298,6 +300,8 @@
 				D3943EDE1FA32D5600898233 /* Info.plist */,
 				EEFD1AB22234A81C00C3C00E /* Redux+Awaitable.swift */,
 				EE7111D42235474B00532177 /* Redux+Core.swift */,
+				EEC1DE84223E035000E4AF43 /* Redux+MainThread.swift */,
+				D350C3581FA345200040556F /* Redux+Store.swift */,
 				EE567CF52236C94A00E907F4 /* Redux+Subscription.swift */,
 				EE567CEF2236BE0D00E907F4 /* Redux+UniqueID.swift */,
 				D3810F5821C0CA550058FA86 /* ReduxLockTest.swift */,
@@ -306,9 +310,8 @@
 				D3803C6421B3E4EB0055467D /* ReduxRouterTest.swift */,
 				D335E28E21B6E689000E664D /* ReduxSagaTest.swift */,
 				D334ED5E21B773CA004C538E /* ReduxSagaTest+Effect.swift */,
-				D350C3581FA345200040556F /* Redux+Store.swift */,
-				D30DBF9C21AD8E2900CD1233 /* ReduxUITest.swift */,
-				EEC1DE84223E035000E4AF43 /* Redux+MainThread.swift */,
+				D30DBF9C21AD8E2900CD1233 /* Redux+UI.swift */,
+				EE57167C223F2A23009B8D87 /* Redux+UI+Integration.swift */,
 			);
 			path = SwiftReduxTests;
 			sourceTree = "<group>";
@@ -810,7 +813,8 @@
 			files = (
 				D3803C6521B3E4EB0055467D /* ReduxRouterTest.swift in Sources */,
 				D350C3591FA345200040556F /* Redux+Store.swift in Sources */,
-				D30DBF9D21AD8E2900CD1233 /* ReduxUITest.swift in Sources */,
+				D30DBF9D21AD8E2900CD1233 /* Redux+UI.swift in Sources */,
+				EE57167D223F2A23009B8D87 /* Redux+UI+Integration.swift in Sources */,
 				D335E28F21B6E689000E664D /* ReduxSagaTest.swift in Sources */,
 				D30CC2FF205C40F0005B5EA1 /* ReduxPresetTest.swift in Sources */,
 				D3810F5921C0CA550058FA86 /* ReduxLockTest.swift in Sources */,

--- a/SwiftRedux/UI+Test/Redux+MockProps.swift
+++ b/SwiftRedux/UI+Test/Redux+MockProps.swift
@@ -11,7 +11,7 @@
 ///     let staticProps = MockStaticProps(...)
 ///     vc.staticProps = staticProps
 ///
-public final class MockStaticProps<State>: StaticProps<State> {
+public final class MockStaticProps<State>: StaticPropContainer<State> {
 
   /// This initializer can be used to construct test static props.
   convenience public init(injector: PropInjector<State>) {

--- a/SwiftRedux/UI/Redux+PropContainer.swift
+++ b/SwiftRedux/UI/Redux+PropContainer.swift
@@ -29,19 +29,33 @@ public protocol PropContainerType: class, UniqueIDProviderType {
   associatedtype ActionProps
   
   /// Convenience type for static props.
-  typealias Static = StaticProps<GlobalState>
+  typealias StaticProps = StaticPropContainer<GlobalState>
+  
+  /// Convenience type for variable props.
+  typealias ReduxProps = ReduxPropContainer<StateProps, ActionProps>
   
   /// This prop container includes static dependencies that can be used to
   /// wire up child views/view controllers.
-  var staticProps: Static? { get set }
+  var staticProps: StaticProps! { get set }
   
   /// This container includes various Redux-related props, most notably state
   /// and action.
-  var reduxProps: ReduxProps<StateProps, ActionProps>? { get set }
+  var reduxProps: ReduxProps? { get set }
 }
 
 /// Generally the Redux view also implements the prop mapper protocol, so in
 /// this case we can define some default generics.
 public extension PropContainerType where Self: PropMapperType {
   public typealias PropContainer = Self
+}
+
+public extension PropContainerType {
+  
+  /// Ensure reduxProps is non-nil.
+  ///
+  /// - Returns: A ReduxProps instance.
+  public func requireReduxProps() -> ReduxProps {
+    precondition(self.reduxProps != nil)
+    return self.reduxProps!
+  }
 }

--- a/SwiftRedux/UI/Redux+PropContainer.swift
+++ b/SwiftRedux/UI/Redux+PropContainer.swift
@@ -31,15 +31,13 @@ public protocol PropContainerType: class, UniqueIDProviderType {
   /// Convenience type for static props.
   typealias Static = StaticProps<GlobalState>
   
-  /// Convenience type for variable props.
-  typealias Variables = VariableProps<StateProps, ActionProps>
-  
   /// This prop container includes static dependencies that can be used to
   /// wire up child views/view controllers.
   var staticProps: Static? { get set }
   
-  /// This prop container includes variable state/action props.
-  var variableProps: Variables? { get set }
+  /// This container includes various Redux-related props, most notably state
+  /// and action.
+  var reduxProps: ReduxProps<StateProps, ActionProps>? { get set }
 }
 
 /// Generally the Redux view also implements the prop mapper protocol, so in

--- a/SwiftRedux/UI/Redux+PropInjector.swift
+++ b/SwiftRedux/UI/Redux+PropInjector.swift
@@ -140,13 +140,7 @@ public class PropInjector<GlobalState>: PropInjectorType {
         let next = MP.mapState(state: s, outProps: op)
         
         if first || !MP.compareState(lhs: previous, rhs: next) {
-          cv?.variableProps = VariableProps(
-            firstInstance: first,
-            previousState: previous,
-            nextState: next,
-            action: action
-          )
-
+          cv?.variableProps = VariableProps(first, next, action)
           previous = next
           first = false
         }

--- a/SwiftRedux/UI/Redux+PropInjector.swift
+++ b/SwiftRedux/UI/Redux+PropInjector.swift
@@ -140,7 +140,7 @@ public class PropInjector<GlobalState>: PropInjectorType {
       defer { semaphore.signal() }
       
       if first || !MP.compareState(previous, next) {
-        runner.runOnMainThread {cv?.reduxProps = ReduxProps(first, next, action)}
+        runner.runOnMainThread {cv?.reduxProps = ReduxPropContainer(first, next, action)}
         previous = next
         first = false
       }
@@ -155,7 +155,7 @@ public class PropInjector<GlobalState>: PropInjectorType {
     let subscription = self.store
       .subscribeState(cv.uniqueID) {[weak cv] state in setProps(cv, state)}
     
-    cv.staticProps = StaticProps(self, subscription)
+    cv.staticProps = StaticPropContainer(self, subscription)
     return subscription
   }
 }

--- a/SwiftRedux/UI/Redux+PropInjector.swift
+++ b/SwiftRedux/UI/Redux+PropInjector.swift
@@ -140,7 +140,7 @@ public class PropInjector<GlobalState>: PropInjectorType {
       defer { semaphore.signal() }
       
       if first || !MP.compareState(previous, next) {
-        runner.runOnMainThread {cv?.variableProps = VariableProps(first, next, action)}
+        runner.runOnMainThread {cv?.reduxProps = ReduxProps(first, next, action)}
         previous = next
         first = false
       }

--- a/SwiftRedux/UI/Redux+PropMapper.swift
+++ b/SwiftRedux/UI/Redux+PropMapper.swift
@@ -53,13 +53,13 @@ public protocol PropMapperType: class {
   ///   - lhs: Previous StateProps.
   ///   - rhs: Next StateProps.
   /// - Returns: A Bool instance.
-  static func compareState(lhs: State?, rhs: State?) -> Bool
+  static func compareState(_ lhs: State?, _ rhs: State?) -> Bool
 }
 
 /// We should make state props conform to Equatable, so that some defaults
 /// can be implemented.
 public extension PropMapperType where State: Equatable {
-  public static func compareState(lhs: State?, rhs: State?) -> Bool {
+  public static func compareState(_ lhs: State?, _ rhs: State?) -> Bool {
     return lhs == rhs
   }
 }

--- a/SwiftRedux/UI/Redux+Props.swift
+++ b/SwiftRedux/UI/Redux+Props.swift
@@ -21,8 +21,8 @@ public class StaticProps<State> {
   }
 }
 
-/// Variable props container.
-public struct VariableProps<StateProps, ActionProps> {
+/// Redux props container.
+public struct ReduxProps<StateProps, ActionProps> {
   
   /// True if this is the first prop event.
   public let firstInstance: Bool

--- a/SwiftRedux/UI/Redux+Props.swift
+++ b/SwiftRedux/UI/Redux+Props.swift
@@ -27,22 +27,17 @@ public struct VariableProps<StateProps, ActionProps> {
   /// True if this is the first prop event.
   public let firstInstance: Bool
   
-  /// The previous state props.
-  public let previousState: StateProps?
-  
-  /// The next state props.
-  public let nextState: StateProps
+  /// The state props.
+  public let state: StateProps
   
   /// Props to store Redux actions.
   public let action: ActionProps
   
-  public init(firstInstance: Bool = false,
-              previousState: StateProps? = nil,
-              nextState: StateProps,
-              action: ActionProps) {
+  public init(_ firstInstance: Bool = false,
+              _ state: StateProps,
+              _ action: ActionProps) {
     self.firstInstance = firstInstance
-    self.previousState = previousState
-    self.nextState = nextState
+    self.state = state
     self.action = action
   }
 }

--- a/SwiftRedux/UI/Redux+Props.swift
+++ b/SwiftRedux/UI/Redux+Props.swift
@@ -7,7 +7,7 @@
 //
 
 /// Static props container.
-public class StaticProps<State> {
+public class StaticPropContainer<State> {
   
   /// The injector instance used to inject Redux props into compatible views.
   public let injector: PropInjector<State>
@@ -22,7 +22,7 @@ public class StaticProps<State> {
 }
 
 /// Redux props container.
-public struct ReduxProps<StateProps, ActionProps> {
+public struct ReduxPropContainer<StateProps, ActionProps> {
   
   /// True if this is the first prop event.
   public let firstInstance: Bool

--- a/SwiftReduxTests/Redux+UI+Integration.swift
+++ b/SwiftReduxTests/Redux+UI+Integration.swift
@@ -28,15 +28,13 @@ public final class ReduxUIIntegrationTest: XCTestCase {
       typealias GlobalState = Int
       typealias PropContainer = TestContainer
       typealias OutProps = ()
-      typealias StateProps = Int
-      typealias ActionProps = ()
       let uniqueID = DefaultUniqueIDProvider.next()
       
       var staticProps: Static?
       
-      var variableProps: Variables? {
+      var reduxProps: ReduxProps<Int, ()>? {
         didSet {
-          if let value = self.variableProps?.state {
+          if let value = self.reduxProps?.state {
             onStateChange?(value)
           }
         }

--- a/SwiftReduxTests/Redux+UI+Integration.swift
+++ b/SwiftReduxTests/Redux+UI+Integration.swift
@@ -28,11 +28,13 @@ public final class ReduxUIIntegrationTest: XCTestCase {
       typealias GlobalState = Int
       typealias PropContainer = TestContainer
       typealias OutProps = ()
+      typealias StateProps = Int
+      typealias ActionProps = ()
       let uniqueID = DefaultUniqueIDProvider.next()
       
-      var staticProps: Static?
+      var staticProps: StaticProps!
       
-      var reduxProps: ReduxProps<Int, ()>? {
+      var reduxProps: ReduxProps? {
         didSet {
           if let value = self.reduxProps?.state {
             onStateChange?(value)

--- a/SwiftReduxTests/Redux+UI+Integration.swift
+++ b/SwiftReduxTests/Redux+UI+Integration.swift
@@ -1,0 +1,75 @@
+//
+//  Redux+UI+Integration.swift
+//  SwiftReduxTests
+//
+//  Created by Viethai Pham on 18/3/19.
+//  Copyright © 2019 Hai Pham. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftRedux
+
+public final class ReduxUIIntegrationTest: XCTestCase {
+  func test_streamingStateFromMultipleThreads_shouldMaintainThreadSafety() {
+    /// Setup
+    class Action: ReduxActionType {}
+    
+    class TestContainer: PropContainerType, PropMapperType {
+      static func mapState(state: Int, outProps: OutProps) -> StateProps {
+        return state
+      }
+      
+      static func mapAction(dispatch: @escaping ReduxDispatcher,
+                            state: Int,
+                            outProps: OutProps) -> ActionProps {
+        return ()
+      }
+      
+      typealias GlobalState = Int
+      typealias PropContainer = TestContainer
+      typealias OutProps = ()
+      typealias StateProps = Int
+      typealias ActionProps = ()
+      let uniqueID = DefaultUniqueIDProvider.next()
+      
+      var staticProps: Static?
+      
+      var variableProps: Variables? {
+        didSet {
+          if let value = self.variableProps?.state {
+            onStateChange?(value)
+          }
+        }
+      }
+      
+      var onStateChange: ((Int) -> Void)?
+    }
+    
+    let store = SimpleStore.create(0) {s, _ in s + 1}
+    let injector = PropInjector(store: store)
+    let container = TestContainer()
+    let dispatchGroup = DispatchGroup()
+    let iteration = 1000
+    var injectedStateProps = [Int]()
+    container.onStateChange = {injectedStateProps.append($0)}
+    
+    /// When
+    let subscription = injector.injectProps(container, (), TestContainer.self)
+    (0..<iteration).forEach({_ in dispatchGroup.enter()})
+    
+    (0..<iteration).forEach {i in
+      DispatchQueue.global(qos: .background).async {
+        _ = store.dispatch(Action())
+        dispatchGroup.leave()
+      }
+    }
+    
+    /// Then
+    dispatchGroup.wait()
+    subscription.unsubscribe()
+    
+    DispatchQueue.main.async {
+      XCTAssertEqual(injectedStateProps, (0...iteration).map({$0}))
+    }
+  }
+}

--- a/SwiftReduxTests/Redux+UI.swift
+++ b/SwiftReduxTests/Redux+UI.swift
@@ -195,11 +195,11 @@ extension ReduxUITests {
     let uniqueID = DefaultUniqueIDProvider.next()
     var staticProps: StaticProps<StateProps>?
     
-    var variableProps: VariableProps<StateProps, ActionProps>? {
+    var reduxProps: ReduxProps<StateProps, ActionProps>? {
       didSet {
         self.setPropCount += 1
         self.injectCallback?(self.setPropCount)
-        self.variableProps?.action()
+        self.reduxProps?.action()
       }
     }
     
@@ -213,11 +213,11 @@ extension ReduxUITests {
     let uniqueID = DefaultUniqueIDProvider.next()
     var staticProps: StaticProps<StateProps>?
     
-    var variableProps: VariableProps<StateProps, ActionProps>? {
+    var reduxProps: ReduxProps<StateProps, ActionProps>? {
       didSet {
         self.setPropCount += 1
         self.injectCallback?(self.setPropCount)
-        self.variableProps?.action()
+        self.reduxProps?.action()
       }
     }
     
@@ -236,10 +236,6 @@ extension ReduxUITests.TestViewController: TestReduxViewType {
   typealias OutProps = Int
   typealias StateProps = ReduxUITests.TestState
   typealias ActionProps = () -> Void
-  
-  func beforePropInjectionStarts(sp: StaticProps<GlobalState>) {}
-  
-  func afterPropInjectionEnds(sp: StaticProps<GlobalState>) {}
 }
 
 extension ReduxUITests.TestViewController: PropMapperType {
@@ -259,10 +255,6 @@ extension ReduxUITests.TestView: TestReduxViewType {
   typealias OutProps = Int
   typealias StateProps = ReduxUITests.TestState
   typealias ActionProps = () -> Void
-  
-  func beforePropInjectionStarts(sp: StaticProps<GlobalState>) {}
-  
-  func afterPropInjectionEnds(sp: StaticProps<GlobalState>) {}
 }
 
 extension ReduxUITests.TestView: PropMapperType {

--- a/SwiftReduxTests/Redux+UI.swift
+++ b/SwiftReduxTests/Redux+UI.swift
@@ -193,13 +193,13 @@ extension ReduxUITests {
   final class TestViewController: UIViewController {
     deinit { print("Deinit \(self)"); self.onDeinit?() }
     let uniqueID = DefaultUniqueIDProvider.next()
-    var staticProps: StaticProps<StateProps>?
+    var staticProps: StaticPropContainer<StateProps>!
     
-    var reduxProps: ReduxProps<StateProps, ActionProps>? {
+    var reduxProps: ReduxProps? {
       didSet {
         self.setPropCount += 1
         self.injectCallback?(self.setPropCount)
-        self.reduxProps?.action()
+        self.reduxProps!.action()
       }
     }
     
@@ -211,13 +211,13 @@ extension ReduxUITests {
   final class TestView: UIView {
     deinit { print("Deinit \(self)"); self.onDeinit?() }
     let uniqueID = DefaultUniqueIDProvider.next()
-    var staticProps: StaticProps<StateProps>?
+    var staticProps: StaticPropContainer<StateProps>!
     
-    var reduxProps: ReduxProps<StateProps, ActionProps>? {
+    var reduxProps: ReduxProps? {
       didSet {
         self.setPropCount += 1
         self.injectCallback?(self.setPropCount)
-        self.reduxProps?.action()
+        self.requireReduxProps().action()
       }
     }
     


### PR DESCRIPTION
- Standardize props with naming conventions and typealiases.
- Add method to `requireReduxProps` to conveniently (but fatally, in some cases) get `reduxProps`.