### PR TITLE
Simpler Saga generics

### DIFF
--- a/SwiftRedux-Demo/Redux+Saga.swift
+++ b/SwiftRedux-Demo/Redux+Saga.swift
@@ -19,8 +19,8 @@ final class AppReduxSaga {
     }
   }
   
-  static func autocompleteSaga(_ input: String) -> SagaEffect<State, Any> {
-    return SagaEffect<State, Bool>
+  static func autocompleteSaga(_ input: String) -> SagaEffect<Any> {
+    return SagaEffect<Bool>
       .just(true).put(AppRedux.Action.progress)
       .then(input).call(Api.performAutocomplete)
       .doOnError({print($0)})
@@ -31,7 +31,7 @@ final class AppReduxSaga {
       .then(false).put(AppRedux.Action.progress)
   }
   
-  static func sagas() -> [SagaEffect<State, Any>] {
+  static func sagas() -> [SagaEffect<Any>] {
     return [
       SagaEffect.takeEvery(
         paramExtractor: extractAutocompleteInput,

--- a/SwiftRedux/Middleware+Saga/Protocols+Saga.swift
+++ b/SwiftRedux/Middleware+Saga/Protocols+Saga.swift
@@ -9,16 +9,13 @@
 /// Implement this protocol to convert to an effect instance.
 public protocol SagaEffectConvertibleType {
   
-  /// The app-specific state type.
-  associatedtype State
-  
   /// The type of the effect's output value.
   associatedtype R
   
   /// Convert the current object into an Effect.
   ///
   /// - Returns: An Effect instance.
-  func asEffect() -> SagaEffect<State, R>
+  func asEffect() -> SagaEffect<R>
 }
 
 /// Implement this protocol to represent a Redux saga effect.
@@ -28,7 +25,7 @@ public protocol SagaEffectType: SagaEffectConvertibleType {
   ///
   /// - Parameter input: A Saga Input instance.
   /// - Returns: A Saga Output instance.
-  func invoke(_ input: SagaInput<State>) -> SagaOutput<R>
+  func invoke(_ input: SagaInput) -> SagaOutput<R>
 }
 
 extension SagaEffectConvertibleType {
@@ -38,8 +35,8 @@ extension SagaEffectConvertibleType {
   /// - Parameter effectCreator: The effect creator function.
   /// - Returns: An Effect instance.
   public func transform<R2>(
-    with effectCreator: SagaEffectTransformer<State, R, R2>)
-    -> SagaEffect<State, R2>
+    with effectCreator: SagaEffectTransformer<R, R2>)
+    -> SagaEffect<R2>
   {
     return effectCreator(self.asEffect())
   }
@@ -55,7 +52,7 @@ extension SagaEffectType {
   ///   - dispatch: The action dispatch function.
   /// - Returns: An Output instance.
   public func invoke(
-    withState state: State,
+    withState state: Any,
     dispatch: @escaping AwaitableReduxDispatcher = NoopDispatcher.instance)
     -> SagaOutput<R> {
     return self.invoke(SagaInput({state}, dispatch))

--- a/SwiftRedux/Middleware+Saga/Redux+Middleware+Saga.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Middleware+Saga.swift
@@ -9,9 +9,9 @@
 /// Hook up sagas by subscribing for inner values and dispatching action for
 /// each saga output every time a new action arrives.
 public struct SagaMiddleware<State>: MiddlewareProviderType {
-  private let effects: [SagaEffect<State, Any>]
+  private let effects: [SagaEffect<Any>]
   
-  public init<S>(effects: S) where S: Sequence, S.Element == SagaEffect<State, Any> {
+  public init<S>(effects: S) where S: Sequence, S.Element == SagaEffect<Any> {
     self.effects = Array(effects)
   }
   

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Call.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Call.swift
@@ -11,17 +11,17 @@ import SwiftFP
 
 /// Effect whose output performs some asynchronous work and then emit the
 /// result.
-public final class CallEffect<State, P, R>: SagaEffect<State, R> {
-  private let _param: SagaEffect<State, P>
+public final class CallEffect<P, R>: SagaEffect<R> {
+  private let _param: SagaEffect<P>
   private let _callCreator: (P) -> Observable<R>
   
-  public init(_ param: SagaEffect<State, P>,
+  public init(_ param: SagaEffect<P>,
               _ callCreator: @escaping (P) -> Observable<R>) {
     self._param = param
     self._callCreator = callCreator
   }
   
-  override public func invoke(_ input: SagaInput<State>) -> SagaOutput<R> {
+  override public func invoke(_ input: SagaInput) -> SagaOutput<R> {
     return self._param.invoke(input).flatMap(self._callCreator)
   }
 }
@@ -32,11 +32,9 @@ extension SagaEffectConvertibleType {
   ///
   /// - Parameter callCreator: A call creator function.
   /// - Returns: An Effect instance.
-  public func call<R2>(_ callCreator: @escaping (R) -> Observable<R2>)
-    -> SagaEffect<State, R2>
-  {
+  public func call<R2>(_ callCreator: @escaping (R) -> Observable<R2>) -> SagaEffect<R2> {
     return self.asEffect().transform(with: {
-      SagaEffect<State, R>.call(with: $0, callCreator: callCreator)
+      SagaEffect<R>.call(with: $0, callCreator: callCreator)
     })
   }
   
@@ -46,10 +44,10 @@ extension SagaEffectConvertibleType {
   /// - Returns: An Effect instance.
   public func call<R2>(
     _ callCreator: @escaping (R, @escaping (Try<R2>) -> Void) -> Void)
-    -> SagaEffect<State, R2>
+    -> SagaEffect<R2>
   {
     return self.asEffect().transform(with: {
-      SagaEffect<State, R>.call(with: $0, callCreator: callCreator)
+      SagaEffect<R>.call(with: $0, callCreator: callCreator)
     })
   }
   
@@ -59,7 +57,7 @@ extension SagaEffectConvertibleType {
   /// - Returns: An Effect instance.
   public func call<R2>(
     _ callCreator: @escaping (R, @escaping (R2?, Error?) -> Void) -> Void)
-    -> SagaEffect<State, R2>
+    -> SagaEffect<R2>
   {
     return self.asEffect().transform(with: {
       SagaEffect.call(with: $0, callCreator: callCreator)

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+CatchError.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+CatchError.swift
@@ -8,17 +8,17 @@
 
 /// Effect whose output catches error from another effect's output and return
 /// some fallback effect.
-public final class CatchErrorEffect<State, R>: SagaEffect<State, R> {
-  private let _source: SagaEffect<State, R>
-  private let _catcher: (Swift.Error) throws -> SagaEffect<State, R>
+public final class CatchErrorEffect<R>: SagaEffect<R> {
+  private let _source: SagaEffect<R>
+  private let _catcher: (Swift.Error) throws -> SagaEffect<R>
   
-  init(_ source: SagaEffect<State, R>,
-       _ catcher: @escaping (Swift.Error) throws -> SagaEffect<State, R>) {
+  init(_ source: SagaEffect<R>,
+       _ catcher: @escaping (Swift.Error) throws -> SagaEffect<R>) {
     self._source = source
     self._catcher = catcher
   }
   
-  override public func invoke(_ input: SagaInput<State>) -> SagaOutput<R> {
+  override public func invoke(_ input: SagaInput) -> SagaOutput<R> {
     return self._source.invoke(input).catchError({try self._catcher($0).invoke(input)})
   }
 }
@@ -30,8 +30,8 @@ extension SagaEffectConvertibleType {
   /// - Parameter catcher: The error catcher function.
   /// - Returns: An Effect instance.
   public func catchError(
-    _ catcher: @escaping (Swift.Error) throws -> SagaEffect<State, R>)
-    -> SagaEffect<State, R>
+    _ catcher: @escaping (Swift.Error) throws -> SagaEffect<R>)
+    -> SagaEffect<R>
   {
     return self.asEffect().transform(with: {.catchError($0, catcher: catcher)})
   }
@@ -41,9 +41,7 @@ extension SagaEffectConvertibleType {
   ///
   /// - Parameter catcher: The error catcher function.
   /// - Returns: An Effect instance.
-  public func catchError(_ catcher: @escaping (Swift.Error) throws -> R)
-    -> SagaEffect<State, R>
-  {
+  public func catchError(_ catcher: @escaping (Swift.Error) throws -> R) -> SagaEffect<R> {
     return self.catchError({.just(try catcher($0))})
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+CompactMap.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+CompactMap.swift
@@ -14,7 +14,7 @@ extension SagaEffectConvertibleType {
   ///
   /// - Parameter selector: The mapper function.
   /// - Returns: An Effect instance.
-  public func compactMap<R2>(_ mapper: @escaping (R) throws -> R2?) -> SagaEffect<State, R2> {
+  public func compactMap<R2>(_ mapper: @escaping (R) throws -> R2?) -> SagaEffect<R2> {
     return self.map(mapper).unwrap()
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Delay.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Delay.swift
@@ -9,12 +9,12 @@
 import Foundation
 
 /// Effect whose output delays emission by some period of time.
-public final class DelayEffect<State, R>: SagaEffect<State, R> {
-  private let sourceEffect: SagaEffect<State, R>
+public final class DelayEffect<R>: SagaEffect<R> {
+  private let sourceEffect: SagaEffect<R>
   private let delayTime: TimeInterval
   private let dispatchQueue: DispatchQueue
   
-  init(_ sourceEffect: SagaEffect<State, R>,
+  init(_ sourceEffect: SagaEffect<R>,
        _ delayTime: TimeInterval,
        _ dispatchQueue: DispatchQueue) {
     self.sourceEffect = sourceEffect
@@ -22,7 +22,7 @@ public final class DelayEffect<State, R>: SagaEffect<State, R> {
     self.dispatchQueue = dispatchQueue
   }
   
-  override public func invoke(_ input: SagaInput<State>) -> SagaOutput<R> {
+  override public func invoke(_ input: SagaInput) -> SagaOutput<R> {
     return self.sourceEffect.invoke(input).delay(
       bySeconds: self.delayTime,
       usingQueue: self.dispatchQueue
@@ -38,10 +38,9 @@ extension SagaEffectConvertibleType {
   ///   - sec: The time interval to delay by.
   ///   - queue: The queue to delay on.
   /// - Returns: An Effect instance.
-  public func delay(
-    bySeconds sec: TimeInterval,
-    usingQueue queue: DispatchQueue = .global(qos: .default))
-    -> SagaEffect<State, R>
+  public func delay(bySeconds sec: TimeInterval,
+                    usingQueue queue: DispatchQueue = .global(qos: .default))
+    -> SagaEffect<R>
   {
     return self.asEffect()
       .transform(with: {.delay($0, bySeconds: sec, usingQueue: queue)})

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Do.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Do.swift
@@ -7,34 +7,34 @@
 //
 
 /// Effect whose output performs some side effect on the source effect value.
-public final class DoOnValueEffect<State, R>: SagaEffect<State, R> {
-  private let source: SagaEffect<State, R>
+public final class DoOnValueEffect<R>: SagaEffect<R> {
+  private let source: SagaEffect<R>
   private let sideEffect: (R) throws -> Void
   
-  init(_ source: SagaEffect<State, R>,
+  init(_ source: SagaEffect<R>,
        _ sideEffect: @escaping (R) throws -> Void) {
     self.source = source
     self.sideEffect = sideEffect
   }
   
-  override public func invoke(_ input: SagaInput<State>) -> SagaOutput<R> {
+  override public func invoke(_ input: SagaInput) -> SagaOutput<R> {
     return self.source.invoke(input).doOnValue(self.sideEffect)
   }
 }
 
 /// Effect whose output performs some side effect on the source effect error,
 /// if any.
-public final class DoOnErrorEffect<State, R>: SagaEffect<State, R> {
-  private let source: SagaEffect<State, R>
+public final class DoOnErrorEffect<R>: SagaEffect<R> {
+  private let source: SagaEffect<R>
   private let sideEffect: (Swift.Error) throws -> Void
   
-  init(_ source: SagaEffect<State, R>,
+  init(_ source: SagaEffect<R>,
        _ sideEffect: @escaping (Swift.Error) throws -> Void) {
     self.source = source
     self.sideEffect = sideEffect
   }
   
-  override public func invoke(_ input: SagaInput<State>) -> SagaOutput<R> {
+  override public func invoke(_ input: SagaInput) -> SagaOutput<R> {
     return self.source.invoke(input).doOnError(self.sideEffect)
   }
 }
@@ -45,9 +45,7 @@ extension SagaEffectConvertibleType {
   ///
   /// - Parameter selector: The side effect selector function.
   /// - Returns: An Effect instance.
-  public func doOnValue(_ selector: @escaping (R) throws -> Void)
-    -> SagaEffect<State, R>
-  {
+  public func doOnValue(_ selector: @escaping (R) throws -> Void) -> SagaEffect<R> {
     return self.asEffect().transform(with: {.doOnValue($0, selector: selector)})
   }
   
@@ -55,9 +53,7 @@ extension SagaEffectConvertibleType {
   ///
   /// - Parameter selector: The side effect selector function.
   /// - Returns: An Effect instance.
-  public func doOnError(_ selector: @escaping (Swift.Error) throws -> Void)
-    -> SagaEffect<State, R>
-  {
+  public func doOnError(_ selector: @escaping (Swift.Error) throws -> Void) -> SagaEffect<R> {
     return self.asEffect().transform(with: {.doOnError($0, selector: selector)})
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Effect.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Effect.swift
@@ -8,24 +8,23 @@
 
 /// Transformer function that takes an effect as the input and produces
 /// another effect.
-public typealias SagaEffectTransformer<State, R1, R2> =
-  (SagaEffect<State, R1>) -> SagaEffect<State, R2>
+public typealias SagaEffectTransformer<R1, R2> = (SagaEffect<R1>) -> SagaEffect<R2>
 
 /// Transformer function that transforms one effect into another, with both
 /// effects having the same output value type.
-public typealias MonoEffectTransformer<State, R> = SagaEffectTransformer<State, R, R>
+public typealias MonoEffectTransformer<R> = SagaEffectTransformer<R, R>
 
 /// Base class for a side effect that is able to produce an output stream
 /// based on the current state of the Redux store. Subclasses must override
 /// the main invocation method to customize the saga output.
-public class SagaEffect<State, R>: SagaEffectType {
+public class SagaEffect<R>: SagaEffectType {
   init() {}
   
-  public func invoke(_ input: SagaInput<State>) -> SagaOutput<R> {
+  public func invoke(_ input: SagaInput) -> SagaOutput<R> {
     return SagaOutput(.error(SagaError.unimplemented))
   }
   
-  public func asEffect() -> SagaEffect<State, R> {
+  public func asEffect() -> SagaEffect<R> {
     return self
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Effects.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Effects.swift
@@ -18,10 +18,9 @@ extension SagaEffect {
   ///   - param: The parameter to call with.
   ///   - callCreator: The call creator function.
   /// - Returns: An Effect instance.
-  public static func call<R2>(
-    with param: SagaEffect<State, R>,
-    callCreator: @escaping (R) -> Observable<R2>)
-    -> CallEffect<State, R, R2>
+  public static func call<R2>(with param: SagaEffect<R>,
+                              callCreator: @escaping (R) -> Observable<R2>)
+    -> CallEffect<R, R2>
   {
     return CallEffect(param, callCreator)
   }
@@ -32,10 +31,9 @@ extension SagaEffect {
   ///   - param: The parameter to call with.
   ///   - callCreator: The call creator function.
   /// - Returns: An Effect instance.
-  public static func call<R2>(
-    with param: SagaEffect<State, R>,
-    callCreator: @escaping (R, @escaping (Try<R2>) -> Void) -> Void)
-    -> CallEffect<State, R, R2>
+  public static func call<R2>(with param: SagaEffect<R>,
+                              callCreator: @escaping (R, @escaping (Try<R2>) -> Void) -> Void)
+    -> CallEffect<R, R2>
   {
     return call(with: param) {param in
       return Observable.create({obs in
@@ -59,10 +57,9 @@ extension SagaEffect {
   ///   - param: The parameter to call with.
   ///   - callCreator: The call creator function.
   /// - Returns: An Effect instance.
-  public static func call<R2>(
-    with param: SagaEffect<State, R>,
-    callCreator: @escaping (R, @escaping (R2?, Error?) -> Void) -> Void)
-    -> CallEffect<State, R, R2>
+  public static func call<R2>(with param: SagaEffect<R>,
+                              callCreator: @escaping (R, @escaping (R2?, Error?) -> Void) -> Void)
+    -> CallEffect<R, R2>
   {
     return call(with: param, callCreator: {(p, c: @escaping (Try<R2>) -> Void) in
       callCreator(p) {r, e in
@@ -81,10 +78,9 @@ extension SagaEffect {
   ///   - source: The source effect.
   ///   - catcher: The error catcher function.
   /// - Returns: An Effect instance.
-  public static func catchError(
-    _ source: SagaEffect<State, R>,
-    catcher: @escaping (Swift.Error) throws -> SagaEffect<State, R>)
-    -> CatchErrorEffect<State, R>
+  public static func catchError(_ source: SagaEffect<R>,
+                                catcher: @escaping (Swift.Error) throws -> SagaEffect<R>)
+    -> CatchErrorEffect<R>
   {
     return CatchErrorEffect(source, catcher)
   }
@@ -95,10 +91,9 @@ extension SagaEffect {
   ///   - source: The source effect.
   ///   - selector: The side effect selector function.
   /// - Returns: An Effect instance.
-  public static func doOnValue(
-    _ source: SagaEffect<State, R>,
-    selector: @escaping (R) throws -> Void)
-    -> DoOnValueEffect<State, R>
+  public static func doOnValue(_ source: SagaEffect<R>,
+                               selector: @escaping (R) throws -> Void)
+    -> DoOnValueEffect<R>
   {
     return DoOnValueEffect(source, selector)
   }
@@ -109,10 +104,9 @@ extension SagaEffect {
   ///   - source: The source effect.
   ///   - selector: The side effect selector function.
   /// - Returns: An Effect instance.
-  public static func doOnError(
-    _ source: SagaEffect<State, R>,
-    selector: @escaping (Error) throws -> Void)
-    -> DoOnErrorEffect<State, R>
+  public static func doOnError(_ source: SagaEffect<R>,
+                               selector: @escaping (Error) throws -> Void)
+    -> DoOnErrorEffect<R>
   {
     return DoOnErrorEffect(source, selector)
   }
@@ -120,7 +114,7 @@ extension SagaEffect {
   /// Create an empty effect.
   ///
   /// - Returns: An Effect instance.
-  public static func empty() -> EmptyEffect<State, R> {
+  public static func empty() -> EmptyEffect<R> {
     return EmptyEffect()
   }
   
@@ -130,9 +124,9 @@ extension SagaEffect {
   ///   - source: The source effect to be filtered.
   ///   - predicate: The filter predicate function.
   /// - Returns: An Effect instance.
-  public static func filter(
-    _ source: SagaEffect<State, R>,
-    predicate: @escaping (R) throws -> Bool) -> SagaEffect<State, R>
+  public static func filter(_ source: SagaEffect<R>,
+                            predicate: @escaping (R) throws -> Bool)
+    -> SagaEffect<R>
   {
     return FilterEffect(source, predicate)
   }
@@ -141,7 +135,7 @@ extension SagaEffect {
   ///
   /// - Parameter value: The value to form the effect with.
   /// - Returns: An Effect instance.
-  public static func just(_ value: R) -> JustEffect<State, R> {
+  public static func just(_ value: R) -> JustEffect<R> {
     return JustEffect(value)
   }
   
@@ -151,10 +145,9 @@ extension SagaEffect {
   ///   - source: The source effect.
   ///   - mapper: The mapper function.
   /// - Returns: An Effect instance.
-  public static func map<R2>(
-    _ source: SagaEffect<State, R>,
-    withMapper mapper: @escaping (R) throws -> R2)
-    -> MapEffect<State, R, R2>
+  public static func map<R2>(_ source: SagaEffect<R>,
+                             withMapper mapper: @escaping (R) throws -> R2)
+    -> MapEffect<R, R2>
   {
     return MapEffect(source, mapper)
   }
@@ -167,10 +160,10 @@ extension SagaEffect {
   ///   - queue: The queue on which to dispatch the action.
   /// - Returns: An Effect instance.
   public static func put(
-    _ param: SagaEffect<State, R>,
+    _ param: SagaEffect<R>,
     actionCreator: @escaping (R) -> ReduxActionType,
     usingQueue queue: DispatchQueue = .global(qos: .default))
-    -> PutEffect<State, R>
+    -> PutEffect<R>
   {
     return PutEffect(param, actionCreator, queue)
   }
@@ -186,7 +179,7 @@ extension SagaEffect {
     _ param: R,
     actionCreator: @escaping (R) -> ReduxActionType,
     usingQueue queue: DispatchQueue = .global(qos: .default))
-    -> PutEffect<State, R>
+    -> PutEffect<R>
   {
     return self.put(.just(param), actionCreator: actionCreator, usingQueue: queue)
   }
@@ -195,7 +188,7 @@ extension SagaEffect {
   ///
   /// - Parameter selector: The state selector function.
   /// - Returns: An Effect instance.
-  public static func select(_ selector: @escaping (State) -> R) -> SelectEffect<State, R> {
+  public static func select<State>(_ selector: @escaping (State) -> R) -> SelectEffect<State, R> {
     return SelectEffect(selector)
   }
   
@@ -206,11 +199,11 @@ extension SagaEffect {
   ///   - effect2: The second effect that must happen after the first.
   ///   - selector: The result combine function.
   /// - Returns: An Effect instance.
-  public static func sequentialize<State, R1, R2>(
-    _ effect1: SagaEffect<State, R1>,
-    _ effect2: SagaEffect<State, R2>,
+  public static func sequentialize<R1, R2>(
+    _ effect1: SagaEffect<R1>,
+    _ effect2: SagaEffect<R2>,
     selector: @escaping (R1, R2) throws -> R)
-    -> SequentializeEffect<State, R1, R2, R>
+    -> SequentializeEffect<R1, R2, R>
   {
     return SequentializeEffect(effect1, effect2, selector)
   }
@@ -223,10 +216,10 @@ extension SagaEffect {
   ///   - queue: The dispatch queue to delay on.
   /// - Returns: An Effect instance.
   public static func delay(
-    _ source: SagaEffect<State, R>,
+    _ source: SagaEffect<R>,
     bySeconds sec: TimeInterval,
     usingQueue queue: DispatchQueue = .global(qos: .default))
-    -> DelayEffect<State, R>
+    -> DelayEffect<R>
   {
     return DelayEffect(source, sec, queue)
   }
@@ -240,10 +233,9 @@ extension SagaEffect {
   /// - Returns: An Effect instance.
   public static func takeEvery<Action, R2>(
     paramExtractor: @escaping (Action) -> R?,
-    effectCreator: @escaping (R) -> SagaEffect<State, R2>,
+    effectCreator: @escaping (R) -> SagaEffect<R2>,
     options: TakeOptions = .default())
-    -> TakeEveryEffect<State, Action, R, R2> where
-    Action: ReduxActionType
+    -> TakeEveryEffect<Action, R, R2> where Action: ReduxActionType
   {
     return TakeEveryEffect(paramExtractor, effectCreator, options)
   }
@@ -257,9 +249,9 @@ extension SagaEffect {
   /// - Returns: An Effect instance.
   public static func takeLatest<Action, R2>(
     paramExtractor: @escaping (Action) -> R?,
-    effectCreator: @escaping (R) -> SagaEffect<State, R2>,
+    effectCreator: @escaping (R) -> SagaEffect<R2>,
     options: TakeOptions = .default())
-    -> TakeLatestEffect<State, Action, R, R2> where
+    -> TakeLatestEffect<Action, R, R2> where
     Action: ReduxActionType
   {
     return TakeLatestEffect(paramExtractor, effectCreator, options)

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Empty.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Empty.swift
@@ -7,8 +7,8 @@
 //
 
 /// Empty effect whose output does not stream anything.
-public final class EmptyEffect<State, R>: SagaEffect<State, R> {
-  override public func invoke(_ input: SagaInput<State>) -> SagaOutput<R> {
+public final class EmptyEffect<R>: SagaEffect<R> {
+  override public func invoke(_ input: SagaInput) -> SagaOutput<R> {
     return SagaOutput(.empty())
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Filter.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Filter.swift
@@ -8,16 +8,16 @@
 
 /// Effect whose output emissions will be filtered out using a predicate
 /// function.
-public final class FilterEffect<State, R>: SagaEffect<State, R> {
-  private let _source: SagaEffect<State, R>
+public final class FilterEffect<R>: SagaEffect<R> {
+  private let _source: SagaEffect<R>
   private let _predicate: (R) throws -> Bool
   
-  init(_ source: SagaEffect<State, R>, _ predicate: @escaping (R) throws -> Bool) {
+  init(_ source: SagaEffect<R>, _ predicate: @escaping (R) throws -> Bool) {
     self._source = source
     self._predicate = predicate
   }
   
-  override public func invoke(_ input: SagaInput<State>) -> SagaOutput<R> {
+  override public func invoke(_ input: SagaInput) -> SagaOutput<R> {
     return self._source.invoke(input).filter(self._predicate)
   }
 }
@@ -28,7 +28,7 @@ extension SagaEffectConvertibleType {
   ///
   /// - Parameter predicate: The predicate function.
   /// - Returns: An Effect instance.
-  public func filter(_ predicate: @escaping (R) throws -> Bool) -> SagaEffect<State, R> {
+  public func filter(_ predicate: @escaping (R) throws -> Bool) -> SagaEffect<R> {
     return self.asEffect().transform(with: {.filter($0, predicate: predicate)})
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Just.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Just.swift
@@ -7,14 +7,14 @@
 //
 
 /// Effect whose output simply emits some specified element.
-public final class JustEffect<State, R>: SagaEffect<State, R> {
+public final class JustEffect<R>: SagaEffect<R> {
   private let value: R
   
   init(_ value: R) {
     self.value = value
   }
   
-  override public func invoke(_ input: SagaInput<State>) -> SagaOutput<R> {
+  override public func invoke(_ input: SagaInput) -> SagaOutput<R> {
     return SagaOutput(.just(self.value))
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Map.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Map.swift
@@ -8,16 +8,16 @@
 
 /// Effect whose output maps the value emissions from that of a source to other
 /// values of possible different types.
-public final class MapEffect<State, R1, R2>: SagaEffect<State, R2> {
-  private let source: SagaEffect<State, R1>
+public final class MapEffect<R1, R2>: SagaEffect<R2> {
+  private let source: SagaEffect<R1>
   private let mapper: (R1) throws -> R2
   
-  init(_ source: SagaEffect<State, R1>, _ mapper: @escaping (R1) throws -> R2) {
+  init(_ source: SagaEffect<R1>, _ mapper: @escaping (R1) throws -> R2) {
     self.source = source
     self.mapper = mapper
   }
   
-  override public func invoke(_ input: SagaInput<State>) -> SagaOutput<R2> {
+  override public func invoke(_ input: SagaInput) -> SagaOutput<R2> {
     return self.source.invoke(input).map(self.mapper)
   }
 }
@@ -28,7 +28,7 @@ extension SagaEffectConvertibleType {
   ///
   /// - Parameter mapper: The mapper function.
   /// - Returns: An Effect instance.
-  public func map<R2>(_ mapper: @escaping (R) throws -> R2) -> SagaEffect<State, R2> {
+  public func map<R2>(_ mapper: @escaping (R) throws -> R2) -> SagaEffect<R2> {
     return self.asEffect().transform(with: {SagaEffect.map($0, withMapper: mapper)})
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Put.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Put.swift
@@ -11,12 +11,12 @@ import RxSwift
 /// Effect whose output puts some external value into the Redux store's managed
 /// state. We may also want to specify the dispatch queue on which to dispatch
 /// the action so that specific order (e.g. serial) may be achieved.
-public final class PutEffect<State, P>: SagaEffect<State, Any> {
+public final class PutEffect<P>: SagaEffect<Any> {
   private let _actionCreator: (P) -> ReduxActionType
-  private let _param: SagaEffect<State, P>
+  private let _param: SagaEffect<P>
   private let _dispatchQueue: DispatchQueue
   
-  init(_ param: SagaEffect<State, P>,
+  init(_ param: SagaEffect<P>,
        _ actionCreator: @escaping (P) -> ReduxActionType,
        _ dispatchQueue: DispatchQueue) {
     self._actionCreator = actionCreator
@@ -24,7 +24,7 @@ public final class PutEffect<State, P>: SagaEffect<State, Any> {
     self._dispatchQueue = dispatchQueue
   }
   
-  override public func invoke(_ input: SagaInput<State>) -> SagaOutput<Any> {
+  override public func invoke(_ input: SagaInput) -> SagaOutput<Any> {
     return _param.invoke(input)
       .map(self._actionCreator)
       .observeOn(ConcurrentDispatchQueueScheduler(queue: self._dispatchQueue))
@@ -40,10 +40,9 @@ extension SagaEffectConvertibleType {
   ///   - actionCreator: The action creator function.
   ///   - queue: The dispatch queue on which to put.
   /// - Returns: An Effect instance.
-  public func put(
-    _ actionCreator: @escaping (R) -> ReduxActionType,
-    usingQueue queue: DispatchQueue = .global(qos: .default))
-    -> SagaEffect<State, Any>
+  public func put(_ actionCreator: @escaping (R) -> ReduxActionType,
+                  usingQueue queue: DispatchQueue = .global(qos: .default))
+    -> SagaEffect<Any>
   {
     return self.asEffect().transform(with: {
       SagaEffect.put($0, actionCreator: actionCreator, usingQueue: queue)

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Select.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Select.swift
@@ -8,14 +8,17 @@
 
 /// Effect whose output selects some value from a Redux store's managed state.
 /// The extracted value can then be fed to other effects.
-public final class SelectEffect<State, R>: SagaEffect<State, R> {
+public final class SelectEffect<State, R>: SagaEffect<R> {
   private let _selector: (State) -> R
   
   init(_ selector: @escaping (State) -> R) {
     self._selector = selector
   }
   
-  override public func invoke(_ input: SagaInput<State>) -> SagaOutput<R> {
-    return SagaOutput(.just(self._selector(input.lastState())))
+  override public func invoke(_ input: SagaInput) -> SagaOutput<R> {
+    let lastState = input.lastState()
+    precondition(lastState is State)
+    let emission = self._selector(lastState as! State)
+    return SagaOutput(.just(emission))
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Take.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Take.swift
@@ -10,16 +10,14 @@ import RxSwift
 
 /// Take effects are streams that filter actions and pluck out the appropriate
 /// ones to perform additional work on.
-public class TakeEffect<State, Action, P, R>: SagaEffect<State, R> where
-  Action: ReduxActionType
-{
+public class TakeEffect<Action, P, R>: SagaEffect<R> where Action: ReduxActionType {
   private let _paramExtractor: (Action) -> P?
-  private let _effectCreator: (P) -> SagaEffect<State, R>
+  private let _effectCreator: (P) -> SagaEffect<R>
   private let _options: TakeOptions
   private let _outputFlattener: (SagaOutput<SagaOutput<R>>) -> SagaOutput<R>
   
   init(_ paramExtractor: @escaping (Action) -> P?,
-       _ effectCreator: @escaping (P) -> SagaEffect<State, R>,
+       _ effectCreator: @escaping (P) -> SagaEffect<R>,
        _ options: TakeOptions,
        _ outputFlattener: @escaping (SagaOutput<SagaOutput<R>>) -> SagaOutput<R>) {
     self._paramExtractor = paramExtractor
@@ -28,7 +26,7 @@ public class TakeEffect<State, Action, P, R>: SagaEffect<State, R> where
     self._outputFlattener = outputFlattener
   }
   
-  override public func invoke(_ input: SagaInput<State>) -> SagaOutput<R> {
+  override public func invoke(_ input: SagaInput) -> SagaOutput<R> {
     let paramStream = PublishSubject<P>()
     let debounce = self._options.debounce
     
@@ -44,11 +42,11 @@ public class TakeEffect<State, Action, P, R>: SagaEffect<State, R> where
 
 /// Effect whose output takes all actions that pass some conditions, then
 /// flattens and emits all values. Contrast this with take latest.
-public final class TakeEveryEffect<State, Action, P, R>:
-  TakeEffect<State, Action, P, R> where Action: ReduxActionType
+public final class TakeEveryEffect<Action, P, R>:
+  TakeEffect<Action, P, R> where Action: ReduxActionType
 {
   init(_ paramExtractor: @escaping (Action) -> P?,
-       _ outputCreator: @escaping (P) -> SagaEffect<State, R>,
+       _ outputCreator: @escaping (P) -> SagaEffect<R>,
        _ options: TakeOptions) {
     super.init(paramExtractor, outputCreator, options, {$0.flatMap({$0})})
   }
@@ -59,11 +57,11 @@ public final class TakeEveryEffect<State, Action, P, R>:
 /// value, such as in an autocomplete search implementation. We define the
 /// type of action and param extractor to filter out actions we are not
 /// interested in.
-public final class TakeLatestEffect<State, Action, P, R>:
-  TakeEffect<State, Action, P, R> where Action: ReduxActionType
+public final class TakeLatestEffect<Action, P, R>:
+  TakeEffect<Action, P, R> where Action: ReduxActionType
 {
   init(_ paramExtractor: @escaping (Action) -> P?,
-       _ outputCreator: @escaping (P) -> SagaEffect<State, R>,
+       _ outputCreator: @escaping (P) -> SagaEffect<R>,
        _ options: TakeOptions) {
     super.init(paramExtractor, outputCreator, options, {$0.switchMap({$0})})
   }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Unwrap.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Unwrap.swift
@@ -14,7 +14,7 @@ extension SagaEffectConvertibleType where R: OptionalType {
   /// emit nothing.
   ///
   /// - Returns: An Effect instance.
-  public func unwrap() -> SagaEffect<State, R.Value> {
+  public func unwrap() -> SagaEffect<R.Value> {
     return self.filter({$0.isSome}).map({$0.value!})
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga.swift
@@ -27,11 +27,11 @@ public enum SagaError: LocalizedError {
 }
 
 /// Input for each saga effect.
-public struct SagaInput<State> {
-  let lastState: ReduxStateGetter<State>
+public struct SagaInput {
+  let lastState: ReduxStateGetter<Any>
   let dispatch: AwaitableReduxDispatcher
   
-  init(_ lastState: @escaping ReduxStateGetter<State>,
+  init(_ lastState: @escaping ReduxStateGetter<Any>,
        _ dispatch: @escaping AwaitableReduxDispatcher) {
     self.lastState = lastState
     self.dispatch = dispatch

--- a/SwiftReduxTests/ReduxSagaTest+Effect.swift
+++ b/SwiftReduxTests/ReduxSagaTest+Effect.swift
@@ -23,7 +23,7 @@ final class ReduxSagaEffectTest: XCTestCase {
       return EmptyAwaitable.instance
     }
     
-    let effect = SagaEffect<State, Int>()
+    let effect = SagaEffect<Int>()
     let output = effect.invoke(withState: (), dispatch: dispatch)
     
     /// When
@@ -60,7 +60,7 @@ final class ReduxSagaEffectTest: XCTestCase {
     let api5: (Int, @escaping (Int?, Error?) -> Void) -> Void = {$1(nil, error)}
     let api6: (Int, @escaping (Int?, Error?) -> Void) -> Void = {$1(nil, nil)}
     
-    let paramEffect = SagaEffect<State, Int>.just(300)
+    let paramEffect = SagaEffect.just(300)
     let effect1 = paramEffect.call(api1)
     let effect2 = paramEffect.call(api2)
     let effect3 = paramEffect.call(api3)
@@ -88,7 +88,7 @@ final class ReduxSagaEffectTest: XCTestCase {
     /// Setup
     let scheduler = ConcurrentDispatchQueueScheduler(qos: .background)
 
-    let source = SagaEffect<State, Int>.call(with: .just(1)) {_ in
+    let source = SagaEffect.call(with: .just(1)) {_ in
       return Observable<Int>
         .error(SagaError.unimplemented)
         .delay(2, scheduler: scheduler)
@@ -105,7 +105,7 @@ final class ReduxSagaEffectTest: XCTestCase {
   
   func test_compactMap_shouldFilterNilValues() {
     /// Setup
-    let source = SagaEffect<State, String>.just("a")
+    let source = SagaEffect.just("a")
     let effect1 = source.compactMap(Int.init)
     let effect2 = source.compactMap({$0 + "b"})
     let output1 = effect1.invoke(withState: ())
@@ -125,7 +125,7 @@ final class ReduxSagaEffectTest: XCTestCase {
       return EmptyAwaitable.instance
     }
     
-    let output = SagaEffect<State, Int>.just(400)
+    let output = SagaEffect.just(400)
       .delay(bySeconds: 2, usingQueue: .global(qos: .background))
       .invoke(withState: (), dispatch: dispatch)
     
@@ -143,15 +143,15 @@ final class ReduxSagaEffectTest: XCTestCase {
     var valueCount = 0
     var errorCount = 0
     
-    let transformer: MonoEffectTransformer<State, Int> = {
+    let transformer: MonoEffectTransformer<Int> = {
       $0.doOnValue({_ in valueCount += 1}).doOnError({_ in errorCount += 1})
     }
     
-    let valueSource = SagaEffect<State, Int>
+    let valueSource = SagaEffect<Int>
       .call(with: .just(1), callCreator: {$1($0, nil)})
       .transform(with: transformer)
     
-    let errorSource = SagaEffect<State, Int>
+    let errorSource = SagaEffect<Int>
       .call(with: .just(1), callCreator: {$1(nil, SagaError.unimplemented)})
       .transform(with: transformer)
     
@@ -176,7 +176,7 @@ final class ReduxSagaEffectTest: XCTestCase {
       return EmptyAwaitable.instance
     }
     
-    let effect = SagaEffect<State, Int>.empty()
+    let effect = SagaEffect<Int>.empty()
     let output = effect.invoke(withState: (), dispatch: dispatch)
     
     /// When
@@ -190,7 +190,7 @@ final class ReduxSagaEffectTest: XCTestCase {
   
   func test_filterEffect_shouldFilterOutFailValues() throws {
     /// Setup
-    let source = SagaEffect<State, Int>.just(1)
+    let source = SagaEffect.just(1)
     let effect1 = source.filter({$0 % 2 == 0})
     let effect2 = source.filter({$0 % 2 == 1})
     let output1 = effect1.invoke(withState: ())
@@ -210,7 +210,7 @@ final class ReduxSagaEffectTest: XCTestCase {
       return EmptyAwaitable.instance
     }
     
-    let effect = SagaEffect<State, Int>.just(10)
+    let effect = SagaEffect.just(10)
     let output = effect.invoke(withState: (), dispatch: dispatch)
     
     /// When
@@ -227,7 +227,7 @@ final class ReduxSagaEffectTest: XCTestCase {
   
   func test_mapEffect_shouldMapInnerValue() throws {
     /// Setup
-    let effect = SagaEffect<State, Int>.just(1).map({$0 * 10})
+    let effect = SagaEffect.just(1).map({$0 * 10})
     let output = effect.invoke(withState: ())
     
     /// When
@@ -240,7 +240,7 @@ final class ReduxSagaEffectTest: XCTestCase {
   func test_putEffect_shouldDispatchPutAction() throws {
     /// Setup
     enum Action: ReduxActionType { case input(Int) }
-    typealias E = SagaEffect<State, Int>
+    typealias E = SagaEffect<Int>
     let expect = expectation(description: "Should have completed")
     var dispatchCount = 0
     var actions: [ReduxActionType] = []
@@ -290,7 +290,7 @@ final class ReduxSagaEffectTest: XCTestCase {
       return EmptyAwaitable.instance
     }
     
-    let effect = SagaEffect<State, Int>.select({_ in 100})
+    let effect = SagaEffect.select({(_: State) in 100})
     let output = effect.invoke(withState: (), dispatch: dispatch)
     
     /// When
@@ -309,7 +309,7 @@ final class ReduxSagaEffectTest: XCTestCase {
     /// Setup
     let scheduler = ConcurrentDispatchQueueScheduler(qos: .background)
     
-    let effect1 = SagaEffect<State, Int>.call(with: .just(1)) {
+    let effect1 = SagaEffect.call(with: .just(1)) {
       Observable.just($0).delay(2, scheduler: scheduler)
     }
     
@@ -338,7 +338,7 @@ extension ReduxSagaEffectTest {
   }
   
   func test_takeEffect_shouldTakeAppropriateActions(
-    creator: (@escaping (Int) -> SagaEffect<State, Int>) -> SagaEffect<State, Int>,
+    creator: (@escaping (Int) -> SagaEffect<Int>) -> SagaEffect<Int>,
     outputValues: [Int])
   {
     /// Setup
@@ -349,7 +349,7 @@ extension ReduxSagaEffectTest {
       return EmptyAwaitable.instance
     }
     
-    let callEffectCreator: (Int) -> SagaEffect<State, Int> = {
+    let callEffectCreator: (Int) -> SagaEffect<Int> = {
       SagaEffect.call(with: .just($0)) {
         let scheduler = ConcurrentDispatchQueueScheduler(qos: .background)
         return Observable.just($0).delay(2, scheduler: scheduler)
@@ -403,7 +403,7 @@ extension ReduxSagaEffectTest {
     /// Setup
     let options = TakeOptions.builder().with(debounce: 2).build()
     
-    let effect = SagaEffect<State, Int>.takeEvery(
+    let effect = SagaEffect.takeEvery(
       paramExtractor: {(_: TakeAction) in 1},
       effectCreator: {.just($0)},
       options: options)

--- a/SwiftReduxTests/ReduxSagaTest.swift
+++ b/SwiftReduxTests/ReduxSagaTest.swift
@@ -71,7 +71,7 @@ extension ReduxSagaTest {
 extension ReduxSagaTest {
   typealias State = ()
   
-  final class TestEffect: SagaEffect<State, Any> {
+  final class TestEffect: SagaEffect<Any> {
     var invokeCount: Int
     var onActionCount: Int
     var pastActions: [ReduxActionType]
@@ -82,8 +82,7 @@ extension ReduxSagaTest {
       self.pastActions = []
     }
     
-    override func invoke(_ input: SagaInput<State>) -> SagaOutput<Any>
-    {
+    override func invoke(_ input: SagaInput) -> SagaOutput<Any> {
       self.invokeCount += 1
       
       return SagaOutput(.just(input.lastState())) {


### PR DESCRIPTION
Remove `State` from `SagaEffect` generics since only `SelectEffect` was using it. Now it becomes:

```swift
SagaEffect<R>
SagaEffectTransformer<R1, R2>
MonoSagaEffectTransformer<R>
```