### PR TITLE
Simplify ReadWriteLock methods

### DIFF
--- a/SwiftRedux/Core/Protocols.swift
+++ b/SwiftRedux/Core/Protocols.swift
@@ -53,43 +53,28 @@ public protocol UniqueIDProviderType {
 public protocol ReadWriteLockType {
   
   /// Lock reads for safe property access.
-  ///
-  /// - Parameter wait: Wait if not possible to acquire lock.
-  /// - Returns: Anything that indicates the success of lock acquisition.
-  @discardableResult
-  func lockRead(wait: Bool) -> Bool
+  func lockRead()
   
   /// Lock writes for safe property modification.
-  ///
-  /// - Parameter wait: Wait if not possible to acquire lock.
-  /// - Returns: Anything that indicates the success of lock acquisition.
-  @discardableResult
-  func lockWrite(wait: Bool) -> Bool
+  func lockWrite()
   
   /// Release the lock.
-  ///
-  /// - Returns: Anything that indicates the success of lock acquisition.
-  @discardableResult
-  func unlock() -> Bool
+  func unlock()
 }
 
 public extension ReadWriteLockType {
   
   /// Access some property in a thread-safe manner.
   func access<T>(_ accessor: () throws -> T) rethrows -> T? {
-    if self.lockRead(wait: true) {
-      defer {self.unlock()}
-      return try accessor()
-    }
-    
-    return nil
+    self.lockRead()
+    defer {self.unlock()}
+    return try accessor()
   }
   
   /// Modify some property in a thread-safe manner.
   func modify(_ modifier: () throws -> Void) rethrows {
-    if self.lockWrite(wait: true) {
-      defer {self.unlock()}
-      try modifier()
-    }
+    self.lockWrite()
+    defer {self.unlock()}
+    try modifier()
   }
 }

--- a/SwiftRedux/Core/Redux+RWLock.swift
+++ b/SwiftRedux/Core/Redux+RWLock.swift
@@ -28,26 +28,15 @@ public final class ReadWriteLock: ReadWriteLockType {
   
   deinit {pthread_rwlock_destroy(&self._mainLock)}
   
-  @discardableResult
-  public func lockRead(wait: Bool) -> Bool {
-    let result = wait
-      ? pthread_rwlock_rdlock(&self._mainLock)
-      : pthread_rwlock_tryrdlock(&self._mainLock)
-    
-    return result == 0
+  public func lockRead() {
+    pthread_rwlock_rdlock(&self._mainLock)
   }
   
-  @discardableResult
-  public func lockWrite(wait: Bool) -> Bool {
-    let result = wait
-      ? pthread_rwlock_wrlock(&self._mainLock)
-      : pthread_rwlock_trywrlock(&self._mainLock)
-    
-    return result == 0
+  public func lockWrite() {
+    pthread_rwlock_wrlock(&self._mainLock)
   }
   
-  @discardableResult
-  public func unlock() -> Bool {
-    return pthread_rwlock_unlock(&self._mainLock) == 0
+  public func unlock() {
+    pthread_rwlock_unlock(&self._mainLock)
   }
 }

--- a/SwiftReduxTests/Redux+Awaitable.swift
+++ b/SwiftReduxTests/Redux+Awaitable.swift
@@ -12,7 +12,7 @@ import XCTest
 @testable import SwiftRedux
 
 class AwaitableTests: XCTestCase {
-  private let timeout: Double = 1000
+  private let timeout: Double = 2000
   
   func test_awaitableError_shouldHaveCorrectDescription() {
     /// Setup && When && Then


### PR DESCRIPTION
Simplify ReadWriteLock to remove unused use case (`trywrlock`/`tryrdlock`), so no more `lockRead(force: true/false)` or `lockWrite(force: true/false)`.