### PR TITLE
Add SagaEffects namespace

### DIFF
--- a/SwiftRedux-Demo/Redux+Saga.swift
+++ b/SwiftRedux-Demo/Redux+Saga.swift
@@ -20,7 +20,7 @@ final class AppReduxSaga {
   }
   
   static func autocompleteSaga(_ input: String) -> SagaEffect<Any> {
-    return SagaEffect<Bool>
+    return SagaEffects
       .just(true).put(AppRedux.Action.progress)
       .then(input).call(Api.performAutocomplete)
       .doOnError({print($0)})
@@ -33,7 +33,7 @@ final class AppReduxSaga {
   
   static func sagas() -> [SagaEffect<Any>] {
     return [
-      SagaEffect.takeEvery(
+      SagaEffects.takeEvery(
         paramExtractor: extractAutocompleteInput,
         effectCreator: autocompleteSaga,
         options: TakeOptions.builder().with(debounce: 0.5).build())

--- a/SwiftRedux.xcodeproj/project.pbxproj
+++ b/SwiftRedux.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		D3810F5921C0CA550058FA86 /* ReduxLockTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3810F5821C0CA550058FA86 /* ReduxLockTest.swift */; };
 		D381794921AD015D007B33A6 /* SwiftRedux.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D3943ECE1FA32D5600898233 /* SwiftRedux.framework */; };
 		D3943ED81FA32D5600898233 /* SwiftRedux.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D3943ECE1FA32D5600898233 /* SwiftRedux.framework */; };
+		D3E02A4F2257C1C500AA1F41 /* ReduxSagaTest+TakeEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E02A4E2257C1C500AA1F41 /* ReduxSagaTest+TakeEffect.swift */; };
 		E09B020DCDEFCE60EBFBCA01 /* Pods_SwiftRedux_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9EDBA54900509BCC49BFB00 /* Pods_SwiftRedux_Demo.framework */; };
 		EE3A11A5221D7F4A0023B445 /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEAABD3A221D174500543DE2 /* Protocols.swift */; };
 		EE3A11A7221D7F4A0023B445 /* Redux+RWLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEAABD20221D174500543DE2 /* Redux+RWLock.swift */; };
@@ -134,6 +135,7 @@
 		D3943ECE1FA32D5600898233 /* SwiftRedux.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftRedux.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3943ED71FA32D5600898233 /* SwiftReduxTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftReduxTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3943EDE1FA32D5600898233 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D3E02A4E2257C1C500AA1F41 /* ReduxSagaTest+TakeEffect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReduxSagaTest+TakeEffect.swift"; sourceTree = "<group>"; };
 		E7F56163AB1D6772064939F4 /* Pods-SwiftReduxTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftReduxTests.debug.xcconfig"; path = "Target Support Files/Pods-SwiftReduxTests/Pods-SwiftReduxTests.debug.xcconfig"; sourceTree = "<group>"; };
 		EE567CEF2236BE0D00E907F4 /* Redux+UniqueID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+UniqueID.swift"; sourceTree = "<group>"; };
 		EE567CF12236BF5200E907F4 /* Redux+UniqueID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Redux+UniqueID.swift"; sourceTree = "<group>"; };
@@ -303,6 +305,8 @@
 				EEC1DE84223E035000E4AF43 /* Redux+MainThread.swift */,
 				D350C3581FA345200040556F /* Redux+Store.swift */,
 				EE567CF52236C94A00E907F4 /* Redux+Subscription.swift */,
+				D30DBF9C21AD8E2900CD1233 /* Redux+UI.swift */,
+				EE57167C223F2A23009B8D87 /* Redux+UI+Integration.swift */,
 				EE567CEF2236BE0D00E907F4 /* Redux+UniqueID.swift */,
 				D3810F5821C0CA550058FA86 /* ReduxLockTest.swift */,
 				D3300E1021B3713E00779B7F /* ReduxMiddlewareTest.swift */,
@@ -310,8 +314,7 @@
 				D3803C6421B3E4EB0055467D /* ReduxRouterTest.swift */,
 				D335E28E21B6E689000E664D /* ReduxSagaTest.swift */,
 				D334ED5E21B773CA004C538E /* ReduxSagaTest+Effect.swift */,
-				D30DBF9C21AD8E2900CD1233 /* Redux+UI.swift */,
-				EE57167C223F2A23009B8D87 /* Redux+UI+Integration.swift */,
+				D3E02A4E2257C1C500AA1F41 /* ReduxSagaTest+TakeEffect.swift */,
 			);
 			path = SwiftReduxTests;
 			sourceTree = "<group>";
@@ -821,6 +824,7 @@
 				EEFD1AB32234A81C00C3C00E /* Redux+Awaitable.swift in Sources */,
 				D334ED5F21B773CA004C538E /* ReduxSagaTest+Effect.swift in Sources */,
 				D3300E1121B3713E00779B7F /* ReduxMiddlewareTest.swift in Sources */,
+				D3E02A4F2257C1C500AA1F41 /* ReduxSagaTest+TakeEffect.swift in Sources */,
 				EE567CF02236BE0D00E907F4 /* Redux+UniqueID.swift in Sources */,
 				EEC1DE85223E035000E4AF43 /* Redux+MainThread.swift in Sources */,
 				EE7111D52235474B00532177 /* Redux+Core.swift in Sources */,

--- a/SwiftRedux.xcworkspace/contents.xcworkspacedata
+++ b/SwiftRedux.xcworkspace/contents.xcworkspacedata
@@ -2,9 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:/Users/viethai.pham/Desktop/SwiftRedux/SwiftRedux.xcodeproj">
-   </FileRef>
-   <FileRef
       location = "group:Pods/Pods.xcodeproj">
    </FileRef>
    <FileRef

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Call.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Call.swift
@@ -34,7 +34,7 @@ extension SagaEffectConvertibleType {
   /// - Returns: An Effect instance.
   public func call<R2>(_ callCreator: @escaping (R) -> Observable<R2>) -> SagaEffect<R2> {
     return self.asEffect().transform(with: {
-      SagaEffect<R>.call(with: $0, callCreator: callCreator)
+      SagaEffects.call(with: $0, callCreator: callCreator)
     })
   }
   
@@ -47,7 +47,7 @@ extension SagaEffectConvertibleType {
     -> SagaEffect<R2>
   {
     return self.asEffect().transform(with: {
-      SagaEffect<R>.call(with: $0, callCreator: callCreator)
+      SagaEffects.call(with: $0, callCreator: callCreator)
     })
   }
   
@@ -60,7 +60,7 @@ extension SagaEffectConvertibleType {
     -> SagaEffect<R2>
   {
     return self.asEffect().transform(with: {
-      SagaEffect.call(with: $0, callCreator: callCreator)
+      SagaEffects.call(with: $0, callCreator: callCreator)
     })
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+CatchError.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+CatchError.swift
@@ -33,7 +33,9 @@ extension SagaEffectConvertibleType {
     _ catcher: @escaping (Swift.Error) throws -> SagaEffect<R>)
     -> SagaEffect<R>
   {
-    return self.asEffect().transform(with: {.catchError($0, catcher: catcher)})
+    return self.asEffect().transform(with: {
+      SagaEffects.catchError($0, catcher: catcher)
+    })
   }
   
   /// Convenience method to catch error and return a fallback value instead of
@@ -42,6 +44,6 @@ extension SagaEffectConvertibleType {
   /// - Parameter catcher: The error catcher function.
   /// - Returns: An Effect instance.
   public func catchError(_ catcher: @escaping (Swift.Error) throws -> R) -> SagaEffect<R> {
-    return self.catchError({.just(try catcher($0))})
+    return self.catchError({SagaEffects.just(try catcher($0))})
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Delay.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Delay.swift
@@ -42,7 +42,8 @@ extension SagaEffectConvertibleType {
                     usingQueue queue: DispatchQueue = .global(qos: .default))
     -> SagaEffect<R>
   {
-    return self.asEffect()
-      .transform(with: {.delay($0, bySeconds: sec, usingQueue: queue)})
+    return self.asEffect().transform(with: {
+      SagaEffects.delay($0, bySeconds: sec, usingQueue: queue)
+    })
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Do.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Do.swift
@@ -46,7 +46,9 @@ extension SagaEffectConvertibleType {
   /// - Parameter selector: The side effect selector function.
   /// - Returns: An Effect instance.
   public func doOnValue(_ selector: @escaping (R) throws -> Void) -> SagaEffect<R> {
-    return self.asEffect().transform(with: {.doOnValue($0, selector: selector)})
+    return self.asEffect().transform(with: {
+      SagaEffects.doOnValue($0, selector: selector)
+    })
   }
   
   /// Invoke a do-on-error effect on the current effect.
@@ -54,6 +56,8 @@ extension SagaEffectConvertibleType {
   /// - Parameter selector: The side effect selector function.
   /// - Returns: An Effect instance.
   public func doOnError(_ selector: @escaping (Swift.Error) throws -> Void) -> SagaEffect<R> {
-    return self.asEffect().transform(with: {.doOnError($0, selector: selector)})
+    return self.asEffect().transform(with: {
+      SagaEffects.doOnError($0, selector: selector)
+    })
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Effects.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Effects.swift
@@ -10,7 +10,9 @@ import Foundation
 import RxSwift
 import SwiftFP
 
-extension SagaEffect {
+/// Top-level namespace for Saga effect creator functions.
+public final class SagaEffects {
+  init() {}
   
   /// Create a call effect with an Observable.
   ///
@@ -18,8 +20,8 @@ extension SagaEffect {
   ///   - param: The parameter to call with.
   ///   - callCreator: The call creator function.
   /// - Returns: An Effect instance.
-  public static func call<R2>(with param: SagaEffect<R>,
-                              callCreator: @escaping (R) -> Observable<R2>)
+  public static func call<R, R2>(with param: SagaEffect<R>,
+                                 callCreator: @escaping (R) -> Observable<R2>)
     -> CallEffect<R, R2>
   {
     return CallEffect(param, callCreator)
@@ -31,8 +33,9 @@ extension SagaEffect {
   ///   - param: The parameter to call with.
   ///   - callCreator: The call creator function.
   /// - Returns: An Effect instance.
-  public static func call<R2>(with param: SagaEffect<R>,
-                              callCreator: @escaping (R, @escaping (Try<R2>) -> Void) -> Void)
+  public static func call<R, R2>(
+    with param: SagaEffect<R>,
+    callCreator: @escaping (R, @escaping (Try<R2>) -> Void) -> Void)
     -> CallEffect<R, R2>
   {
     return call(with: param) {param in
@@ -57,8 +60,9 @@ extension SagaEffect {
   ///   - param: The parameter to call with.
   ///   - callCreator: The call creator function.
   /// - Returns: An Effect instance.
-  public static func call<R2>(with param: SagaEffect<R>,
-                              callCreator: @escaping (R, @escaping (R2?, Error?) -> Void) -> Void)
+  public static func call<R, R2>(
+    with param: SagaEffect<R>,
+    callCreator: @escaping (R, @escaping (R2?, Error?) -> Void) -> Void)
     -> CallEffect<R, R2>
   {
     return call(with: param, callCreator: {(p, c: @escaping (Try<R2>) -> Void) in
@@ -78,8 +82,9 @@ extension SagaEffect {
   ///   - source: The source effect.
   ///   - catcher: The error catcher function.
   /// - Returns: An Effect instance.
-  public static func catchError(_ source: SagaEffect<R>,
-                                catcher: @escaping (Swift.Error) throws -> SagaEffect<R>)
+  public static func catchError<R>(
+    _ source: SagaEffect<R>,
+    catcher: @escaping (Swift.Error) throws -> SagaEffect<R>)
     -> CatchErrorEffect<R>
   {
     return CatchErrorEffect(source, catcher)
@@ -91,8 +96,8 @@ extension SagaEffect {
   ///   - source: The source effect.
   ///   - selector: The side effect selector function.
   /// - Returns: An Effect instance.
-  public static func doOnValue(_ source: SagaEffect<R>,
-                               selector: @escaping (R) throws -> Void)
+  public static func doOnValue<R>(_ source: SagaEffect<R>,
+                                  selector: @escaping (R) throws -> Void)
     -> DoOnValueEffect<R>
   {
     return DoOnValueEffect(source, selector)
@@ -104,8 +109,8 @@ extension SagaEffect {
   ///   - source: The source effect.
   ///   - selector: The side effect selector function.
   /// - Returns: An Effect instance.
-  public static func doOnError(_ source: SagaEffect<R>,
-                               selector: @escaping (Error) throws -> Void)
+  public static func doOnError<R>(_ source: SagaEffect<R>,
+                                  selector: @escaping (Error) throws -> Void)
     -> DoOnErrorEffect<R>
   {
     return DoOnErrorEffect(source, selector)
@@ -114,7 +119,7 @@ extension SagaEffect {
   /// Create an empty effect.
   ///
   /// - Returns: An Effect instance.
-  public static func empty() -> EmptyEffect<R> {
+  public static func empty<R>() -> EmptyEffect<R> {
     return EmptyEffect()
   }
   
@@ -124,8 +129,8 @@ extension SagaEffect {
   ///   - source: The source effect to be filtered.
   ///   - predicate: The filter predicate function.
   /// - Returns: An Effect instance.
-  public static func filter(_ source: SagaEffect<R>,
-                            predicate: @escaping (R) throws -> Bool)
+  public static func filter<R>(_ source: SagaEffect<R>,
+                               predicate: @escaping (R) throws -> Bool)
     -> SagaEffect<R>
   {
     return FilterEffect(source, predicate)
@@ -135,7 +140,7 @@ extension SagaEffect {
   ///
   /// - Parameter value: The value to form the effect with.
   /// - Returns: An Effect instance.
-  public static func just(_ value: R) -> JustEffect<R> {
+  public static func just<R>(_ value: R) -> JustEffect<R> {
     return JustEffect(value)
   }
   
@@ -145,8 +150,8 @@ extension SagaEffect {
   ///   - source: The source effect.
   ///   - mapper: The mapper function.
   /// - Returns: An Effect instance.
-  public static func map<R2>(_ source: SagaEffect<R>,
-                             withMapper mapper: @escaping (R) throws -> R2)
+  public static func map<R, R2>(_ source: SagaEffect<R>,
+                                withMapper mapper: @escaping (R) throws -> R2)
     -> MapEffect<R, R2>
   {
     return MapEffect(source, mapper)
@@ -159,7 +164,7 @@ extension SagaEffect {
   ///   - actionCreator: The action creator function.
   ///   - queue: The queue on which to dispatch the action.
   /// - Returns: An Effect instance.
-  public static func put(
+  public static func put<R>(
     _ param: SagaEffect<R>,
     actionCreator: @escaping (R) -> ReduxActionType,
     usingQueue queue: DispatchQueue = .global(qos: .default))
@@ -175,20 +180,23 @@ extension SagaEffect {
   ///   - actionCreator: The action creator function.
   ///   - queue: The queue on which to dispatch the action.
   /// - Returns: An Effect instance.
-  public static func put(
+  public static func put<R>(
     _ param: R,
     actionCreator: @escaping (R) -> ReduxActionType,
     usingQueue queue: DispatchQueue = .global(qos: .default))
     -> PutEffect<R>
   {
-    return self.put(.just(param), actionCreator: actionCreator, usingQueue: queue)
+    return self.put(SagaEffects.just(param),
+                    actionCreator: actionCreator,
+                    usingQueue: queue)
   }
   
   /// Create a select effect.
   ///
   /// - Parameter selector: The state selector function.
   /// - Returns: An Effect instance.
-  public static func select<State>(_ selector: @escaping (State) -> R) -> SelectEffect<State, R> {
+  public static func select<State, R>(_ selector: @escaping (State) -> R)
+    -> SelectEffect<State, R> {
     return SelectEffect(selector)
   }
   
@@ -199,7 +207,7 @@ extension SagaEffect {
   ///   - effect2: The second effect that must happen after the first.
   ///   - selector: The result combine function.
   /// - Returns: An Effect instance.
-  public static func sequentialize<R1, R2>(
+  public static func sequentialize<R, R1, R2>(
     _ effect1: SagaEffect<R1>,
     _ effect2: SagaEffect<R2>,
     selector: @escaping (R1, R2) throws -> R)
@@ -215,7 +223,7 @@ extension SagaEffect {
   ///   - sec: The time in seconds to delay by.
   ///   - queue: The dispatch queue to delay on.
   /// - Returns: An Effect instance.
-  public static func delay(
+  public static func delay<R>(
     _ source: SagaEffect<R>,
     bySeconds sec: TimeInterval,
     usingQueue queue: DispatchQueue = .global(qos: .default))
@@ -231,7 +239,7 @@ extension SagaEffect {
   ///   - effectCreator: The effect creator function.
   ///   - options: Additional take options.
   /// - Returns: An Effect instance.
-  public static func takeEvery<Action, R2>(
+  public static func takeEvery<Action, R, R2>(
     paramExtractor: @escaping (Action) -> R?,
     effectCreator: @escaping (R) -> SagaEffect<R2>,
     options: TakeOptions = .default())
@@ -247,7 +255,7 @@ extension SagaEffect {
   ///   - effectCreator: The effect creator function.
   ///   - options: Additinoal take options.
   /// - Returns: An Effect instance.
-  public static func takeLatest<Action, R2>(
+  public static func takeLatest<Action, R, R2>(
     paramExtractor: @escaping (Action) -> R?,
     effectCreator: @escaping (R) -> SagaEffect<R2>,
     options: TakeOptions = .default())

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Filter.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Filter.swift
@@ -29,6 +29,8 @@ extension SagaEffectConvertibleType {
   /// - Parameter predicate: The predicate function.
   /// - Returns: An Effect instance.
   public func filter(_ predicate: @escaping (R) throws -> Bool) -> SagaEffect<R> {
-    return self.asEffect().transform(with: {.filter($0, predicate: predicate)})
+    return self.asEffect().transform(with: {
+      SagaEffects.filter($0, predicate: predicate)
+    })
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Map.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Map.swift
@@ -29,6 +29,6 @@ extension SagaEffectConvertibleType {
   /// - Parameter mapper: The mapper function.
   /// - Returns: An Effect instance.
   public func map<R2>(_ mapper: @escaping (R) throws -> R2) -> SagaEffect<R2> {
-    return self.asEffect().transform(with: {SagaEffect.map($0, withMapper: mapper)})
+    return self.asEffect().transform(with: {SagaEffects.map($0, withMapper: mapper)})
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Put.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Put.swift
@@ -45,7 +45,7 @@ extension SagaEffectConvertibleType {
     -> SagaEffect<Any>
   {
     return self.asEffect().transform(with: {
-      SagaEffect.put($0, actionCreator: actionCreator, usingQueue: queue)
+      SagaEffects.put($0, actionCreator: actionCreator, usingQueue: queue)
     })
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Sequentialize.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Sequentialize.swift
@@ -42,7 +42,7 @@ extension SagaEffectConvertibleType {
     -> SagaEffect<U>
   {
     return self.asEffect()
-      .transform(with: {.sequentialize($0, effect2, selector: selector)})
+      .transform(with: {SagaEffects.sequentialize($0, effect2, selector: selector)})
   }
   
   /// Trigger another effect and ignore emission from this one.
@@ -58,6 +58,6 @@ extension SagaEffectConvertibleType {
   /// - Parameter value: The value to change to.
   /// - Returns: An Effect instance.
   public func then<R2>(_ value: R2) -> SagaEffect<R2> {
-    return self.then(.just(value))
+    return self.then(SagaEffects.just(value))
   }
 }

--- a/SwiftReduxTests/ReduxSagaTest+TakeEffect.swift
+++ b/SwiftReduxTests/ReduxSagaTest+TakeEffect.swift
@@ -1,0 +1,122 @@
+//
+//  ReduxSagaTest+Effect.swift
+//  SwiftReduxTests
+//
+//  Created by Hai Pham on 12/5/18.
+//  Copyright © 2018 Hai Pham. All rights reserved.
+//
+
+import RxSwift
+import XCTest
+@testable import SwiftRedux
+
+public final class ReduxSagaTakeEffectTest: XCTestCase {
+  private enum TakeAction: ReduxActionType {
+    case a
+    case b
+    
+    var payload: Int? {
+      switch self {
+      case .a: return 1
+      case .b: return nil
+      }
+    }
+  }
+  
+  private func test_takeEffect_shouldTakeAppropriateActions(
+    creator: (@escaping (Int) -> SagaEffect<Int>) -> SagaEffect<Int>,
+    outputValues: [Int])
+  {
+    /// Setup
+    var dispatchCount = 0
+    
+    let dispatch: AwaitableReduxDispatcher = {_ in
+      dispatchCount += 1
+      return EmptyAwaitable.instance
+    }
+    
+    let callEffectCreator: (Int) -> SagaEffect<Int> = {
+      SagaEffects.call(with: SagaEffects.just($0)) {
+        let scheduler = ConcurrentDispatchQueueScheduler(qos: .background)
+        return Observable.just($0).delay(2, scheduler: scheduler)
+      }
+    }
+    
+    let effect = creator(callEffectCreator)
+    let output = effect.invoke(withState: (), dispatch: dispatch)
+    var values: [Int] = []
+    
+    /// When
+    output.subscribe({values.append($0)})
+    _ = output.onAction(TakeAction.a)
+    _ = output.onAction(TakeAction.b)
+    _ = output.onAction(TakeAction.a)
+    _ = output.onAction(DefaultAction.noop)
+    _ = output.onAction(TakeAction.a)
+    
+    /// Then
+    let waitTime = UInt64(pow(10 as Double, 9) * 3)
+    let timeout = DispatchTime.now().uptimeNanoseconds + waitTime
+    let deadline = DispatchTime(uptimeNanoseconds: timeout)
+    let dispatchGroup = DispatchGroup()
+    dispatchGroup.enter()
+    
+    DispatchQueue.global(qos: .background).asyncAfter(deadline: deadline) {
+      dispatchGroup.leave()
+    }
+    
+    dispatchGroup.wait()
+    XCTAssertEqual(values, outputValues)
+  }
+  
+  public func test_takeEveryEffect_shouldTakeAllAction() {
+    self.test_takeEffect_shouldTakeAppropriateActions(
+      creator: {SagaEffects.takeEvery(
+        paramExtractor: {(a: TakeAction) in a.payload},
+        effectCreator: $0)},
+      outputValues: [1, 1, 1])
+  }
+  
+  public func test_takeLatestEffect_shouldTakeLatestAction() {
+    self.test_takeEffect_shouldTakeAppropriateActions(
+      creator: {SagaEffects.takeLatest(
+        paramExtractor: {(a: TakeAction) in a.payload},
+        effectCreator: $0)},
+      outputValues: [1])
+  }
+  
+  public func test_takeEffectDebounce_shouldThrottleEmissions() {
+    /// Setup
+    let options = TakeOptions.builder().with(debounce: 2).build()
+    
+    let effect = SagaEffects.takeEvery(
+      paramExtractor: {(_: TakeAction) in 1},
+      effectCreator: {SagaEffects.just($0)},
+      options: options)
+    
+    let output = effect.invoke(withState: ())
+    var values = [Int]()
+    
+    /// When
+    output.subscribe({values.append($0)})
+    _ = output.onAction(TakeAction.a)
+    _ = output.onAction(TakeAction.a)
+    _ = output.onAction(TakeAction.a)
+    _ = output.onAction(TakeAction.a)
+    _ = output.onAction(TakeAction.a)
+    
+    /// Then
+    let waitTime = UInt64(pow(10 as Double, 9) * 3)
+    let timeout = DispatchTime.now().uptimeNanoseconds + waitTime
+    let deadline = DispatchTime(uptimeNanoseconds: timeout)
+    let dispatchGroup = DispatchGroup()
+    dispatchGroup.enter()
+    
+    DispatchQueue.global(qos: .background).asyncAfter(deadline: deadline) {
+      dispatchGroup.leave()
+    }
+    
+    dispatchGroup.wait()
+    XCTAssertEqual(values, [1])
+  }
+}

--- a/SwiftReduxTests/ReduxSagaTest.swift
+++ b/SwiftReduxTests/ReduxSagaTest.swift
@@ -10,65 +10,7 @@ import RxSwift
 import XCTest
 @testable import SwiftRedux
 
-final class ReduxSagaTest: XCTestCase {
-  private var dispatch: AwaitableReduxDispatcher!
-  private var dispatchCount: Int!
-  private var testEffect: TestEffect!
-  
-  override func setUp() {
-    super.setUp()
-    let input = MiddlewareInput({()})
-    
-    let wrapper = DispatchWrapper("") {_ in
-      self.dispatchCount += 1
-      return EmptyAwaitable.instance
-    }
-    
-    self.dispatchCount = 0
-    self.testEffect = TestEffect()
-
-    self.dispatch = SagaMiddleware(effects: [self.testEffect])
-      .middleware(input)(wrapper).dispatch
-  }
-}
-
-extension ReduxSagaTest {
-  func test_sagaError_shouldHaveDescriptions() {
-    /// Setup && When && Then
-    XCTAssertNotNil(SagaError.unimplemented.errorDescription)
-  }
-  
-  func test_receivingAction_shouldInvokeSagaEffects() {
-    /// Setup && When
-    _ = self.dispatch(DefaultAction.noop)
-    _ = self.dispatch(DefaultAction.noop)
-    _ = self.dispatch(DefaultAction.noop)
-    _ = self.dispatch(DefaultAction.noop)
-    
-    /// Then
-    XCTAssertEqual(self.testEffect.invokeCount, 1)
-    XCTAssertEqual(self.testEffect.onActionCount, 4)
-    
-    XCTAssertEqual(self.testEffect.pastActions as! [DefaultAction],
-                   [.noop, .noop, .noop, .noop])
-  }
-  
-  func test_transformingOutput_shouldWork() throws {
-    /// Setup
-    let output = SagaOutput(.just(0))
-      .map({$0 + 1})
-      .debounce(bySeconds: 1)
-      .printValue()
-    
-    /// When
-    let value = try output.await(timeoutMillis: 10000)
-    
-    /// Then
-    XCTAssertEqual(value, 1)
-  }
-}
-
-extension ReduxSagaTest {
+public final class ReduxSagaTest: XCTestCase {
   typealias State = ()
   
   final class TestEffect: SagaEffect<Any> {
@@ -91,5 +33,61 @@ extension ReduxSagaTest {
         return EmptyAwaitable.instance
       }
     }
+  }
+  
+  private var dispatch: AwaitableReduxDispatcher!
+  private var dispatchCount: Int!
+  private var testEffect: TestEffect!
+  
+  override public func setUp() {
+    super.setUp()
+    let input = MiddlewareInput({()})
+    
+    let wrapper = DispatchWrapper("") {_ in
+      self.dispatchCount += 1
+      return EmptyAwaitable.instance
+    }
+    
+    self.dispatchCount = 0
+    self.testEffect = TestEffect()
+
+    self.dispatch = SagaMiddleware(effects: [self.testEffect])
+      .middleware(input)(wrapper).dispatch
+  }
+
+  public func test_sagaError_shouldHaveDescriptions() {
+    /// Setup && When && Then
+    XCTAssertNotNil(SagaError.unimplemented.errorDescription)
+  }
+  
+  public func test_receivingAction_shouldInvokeSagaEffects() {
+    /// Setup && When
+    _ = self.dispatch(DefaultAction.noop)
+    _ = self.dispatch(DefaultAction.noop)
+    _ = self.dispatch(DefaultAction.noop)
+    _ = self.dispatch(DefaultAction.noop)
+    
+    /// Then
+    XCTAssertEqual(self.testEffect.invokeCount, 1)
+    XCTAssertEqual(self.testEffect.onActionCount, 4)
+    
+    XCTAssertEqual(
+      self.testEffect.pastActions as! [DefaultAction],
+      [.noop, .noop, .noop, .noop]
+    )
+  }
+  
+  public func test_transformingOutput_shouldWork() throws {
+    /// Setup
+    let output = SagaOutput(.just(0))
+      .map({$0 + 1})
+      .debounce(bySeconds: 1)
+      .printValue()
+    
+    /// When
+    let value = try output.await(timeoutMillis: 10000)
+    
+    /// Then
+    XCTAssertEqual(value, 1)
   }
 }


### PR DESCRIPTION
Use `SagaEffects` namespace for convenience `SagaEffect` creation in order to avoid conflicting `SagaEffectType`'s R generic:

```swift
SagaEffects.just(1)
SagaEffects.put(...)
SagaEffects.select({...})
```