### PR TITLE
Await saga for synchronous execution

### DIFF
--- a/SwiftRedux.xcodeproj/project.pbxproj
+++ b/SwiftRedux.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		D3803C6521B3E4EB0055467D /* ReduxRouterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3803C6421B3E4EB0055467D /* ReduxRouterTest.swift */; };
 		D3810F5921C0CA550058FA86 /* ReduxLockTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3810F5821C0CA550058FA86 /* ReduxLockTest.swift */; };
 		D381794921AD015D007B33A6 /* SwiftRedux.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D3943ECE1FA32D5600898233 /* SwiftRedux.framework */; };
+		D38E12B92257AE3600A84040 /* Redux+Saga+Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38E12B82257AE3600A84040 /* Redux+Saga+Await.swift */; };
 		D3943ED81FA32D5600898233 /* SwiftRedux.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D3943ECE1FA32D5600898233 /* SwiftRedux.framework */; };
 		D3E02A4F2257C1C500AA1F41 /* ReduxSagaTest+TakeEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E02A4E2257C1C500AA1F41 /* ReduxSagaTest+TakeEffect.swift */; };
 		E09B020DCDEFCE60EBFBCA01 /* Pods_SwiftRedux_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9EDBA54900509BCC49BFB00 /* Pods_SwiftRedux_Demo.framework */; };
@@ -132,6 +133,7 @@
 		D352CE5F205CB3C800319B07 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		D3803C6421B3E4EB0055467D /* ReduxRouterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReduxRouterTest.swift; sourceTree = "<group>"; };
 		D3810F5821C0CA550058FA86 /* ReduxLockTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReduxLockTest.swift; sourceTree = "<group>"; };
+		D38E12B82257AE3600A84040 /* Redux+Saga+Await.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+Saga+Await.swift"; sourceTree = "<group>"; };
 		D3943ECE1FA32D5600898233 /* SwiftRedux.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftRedux.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3943ED71FA32D5600898233 /* SwiftReduxTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftReduxTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3943EDE1FA32D5600898233 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -364,6 +366,7 @@
 				EEAABD23221D174500543DE2 /* Protocols+Saga.swift */,
 				EEAABD2A221D174500543DE2 /* Redux+Middleware+Saga.swift */,
 				EEAABD24221D174500543DE2 /* Redux+Saga.swift */,
+				D38E12B82257AE3600A84040 /* Redux+Saga+Await.swift */,
 				EEAABD2F221D174500543DE2 /* Redux+Saga+Call.swift */,
 				EEAABD25221D174500543DE2 /* Redux+Saga+CatchError.swift */,
 				EEAABD29221D174500543DE2 /* Redux+Saga+CompactMap.swift */,
@@ -777,6 +780,7 @@
 				EE3A11AE221D7F4A0023B445 /* Redux+Saga+Sequentialize.swift in Sources */,
 				EE3A11AF221D7F4A0023B445 /* Protocols+Saga.swift in Sources */,
 				EE3A11B0221D7F4A0023B445 /* Redux+Saga.swift in Sources */,
+				D38E12B92257AE3600A84040 /* Redux+Saga+Await.swift in Sources */,
 				EE3A11B1221D7F4A0023B445 /* Redux+Saga+CatchError.swift in Sources */,
 				EE3A11B2221D7F4A0023B445 /* Redux+Saga+Take+Option.swift in Sources */,
 				EE3A11B3221D7F4A0023B445 /* Redux+Saga+Effect.swift in Sources */,

--- a/SwiftRedux/Middleware+Saga/Protocols+Saga.swift
+++ b/SwiftRedux/Middleware+Saga/Protocols+Saga.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2018 Hai Pham. All rights reserved.
 //
 
+import SwiftFP
+
 /// Implement this protocol to convert to an effect instance.
 public protocol SagaEffectConvertibleType {
   
@@ -70,6 +72,7 @@ public extension SagaEffectType where Self: SingleSagaEffectType {
   /// - Parameter input: A SagaInput instance.
   /// - Returns: An R value.
   /// - Throws: Error if the resulting saga output fails to wait for result.
+  @discardableResult
   public func await(_ input: SagaInput) throws -> R {
     return try self.invoke(input).await()
   }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Await.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Await.swift
@@ -1,0 +1,28 @@
+//
+//  Redux+Saga+Await.swift
+//  SwiftRedux
+//
+//  Created by Hai Pham on 5/4/19.
+//  Copyright © 2019 Hai Pham. All rights reserved.
+//
+
+import RxSwift
+import SwiftFP
+
+/// Effect whose output emits the value calculated by a creator function. It is
+/// important that all Saga effects involved in that function must return only
+/// one element - i.e. all single-value Saga effects.
+public final class AwaitEffect<T>: SagaEffect<Try<T>> {
+  private let _creator: (SagaInput) throws -> T
+  
+  init(_ creator: @escaping (SagaInput) throws -> T) {
+    self._creator = creator
+  }
+  
+  override public func invoke(_ input: SagaInput) -> SagaOutput<Try<T>> {
+    return SagaOutput(.just(Try {try self._creator(input)}))
+  }
+}
+
+// MARK: - SingleSagaEffectType
+extension AwaitEffect: SingleSagaEffectType {}

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Call.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Call.swift
@@ -26,6 +26,9 @@ public final class CallEffect<P, R>: SagaEffect<R> {
   }
 }
 
+// MARK: - SingleSagaEffectType
+extension CallEffect: SingleSagaEffectType {}
+
 extension SagaEffectConvertibleType {
 
   /// Invoke a call effect on the current effect.

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Effect.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Effect.swift
@@ -24,7 +24,5 @@ public class SagaEffect<R>: SagaEffectType {
     return SagaOutput(.error(SagaError.unimplemented))
   }
   
-  public func asEffect() -> SagaEffect<R> {
-    return self
-  }
+  public func asEffect() -> SagaEffect<R> { return self }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Effects.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Effects.swift
@@ -14,6 +14,16 @@ import SwiftFP
 public final class SagaEffects {
   init() {}
   
+  /// Create an await effect with a creator function.
+  ///
+  /// - Parameter creator: Function that await for results from multiple effects.
+  /// - Returns: An Effect instance.
+  public static func await<R>(with creator: @escaping (SagaInput) throws -> R)
+    -> AwaitEffect<R>
+  {
+    return AwaitEffect(creator)
+  }
+  
   /// Create a call effect with an Observable.
   ///
   /// - Parameters:

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Just.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Just.swift
@@ -18,3 +18,6 @@ public final class JustEffect<R>: SagaEffect<R> {
     return SagaOutput(.just(self.value))
   }
 }
+
+// MARK: - SingleSagaEffectType
+extension JustEffect: SingleSagaEffectType {}

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Put.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Put.swift
@@ -32,6 +32,9 @@ public final class PutEffect<P>: SagaEffect<Any> {
   }
 }
 
+// MARK: - SingleSagaEffectType
+extension PutEffect: SingleSagaEffectType {}
+
 extension SagaEffectConvertibleType {
   
   /// Invoke a put effect on the current effect.

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Select.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Select.swift
@@ -22,3 +22,6 @@ public final class SelectEffect<State, R>: SagaEffect<R> {
     return SagaOutput(.just(emission))
   }
 }
+
+// MARK: - SingleSagaEffectType
+extension SelectEffect: SingleSagaEffectType {}


### PR DESCRIPTION
Add `AwaitEffect` to enable synchronous execution of single-value effects:

```swift
SagaEffects.await {input in
  try SagaEffects.put(0, Action.init).await(input)
  try SagaEffects.put(1, Action.init).await(input)
  try SagaEffects.put(2, Action.init).await(input)
  try SagaEffects.select {(state: State) in state.value}.await(input)
  return 4
}
```