### PR TITLE
Nested router

### DIFF
--- a/SwiftRedux-Demo/Api.swift
+++ b/SwiftRedux-Demo/Api.swift
@@ -10,12 +10,12 @@ import SwiftRedux
 import RxSwift
 
 final class Api {
-  static func performAutocomplete(_ input: String) -> Observable<[String]> {
+  static func performAutocomplete(_ input: String) -> Single<[String]> {
     if Bool.random() {
-      return Observable.error(SagaError.unimplemented)
+      return Single.error(SagaError.unimplemented)
     }
     
-    return Observable.just(())
+    return Single.just(())
       .delay(0.5, scheduler: ConcurrentDispatchQueueScheduler(qos: .background))
       .map({_ in (0...3).map({"Autocompleted \(input): \($0)"})})
   }

--- a/SwiftRedux-Demo/Redux+Router.swift
+++ b/SwiftRedux-Demo/Redux+Router.swift
@@ -15,27 +15,28 @@ public enum ReduxScreen: RouterScreenType {
 }
 
 public struct ReduxRouter: ReduxRouterType {
-  public typealias Screen = ReduxScreen
-  
   private weak var _controller: UINavigationController?
   
   public init(_ controller: UINavigationController) {
     self._controller = controller
   }
   
-  public func navigate(_ screen: ReduxScreen) {
+  public func navigate(_ screen: RouterScreenType) {
     print("Navigating with screen: \(screen)")
     
-    switch screen {
-    case .viewController1:
+    switch screen as? ReduxScreen {
+    case .some(.viewController1):
       let vc = UIStoryboard(name: "Main", bundle: nil)
         .instantiateViewController(withIdentifier: "ViewController1")
         as! ViewController1
       
       self._controller?.pushViewController(vc, animated: true)
       
-    case .back:
+    case .some(.back):
       self._controller?.popViewController(animated: true)
+      
+    default:
+      break
     }
   }
 }

--- a/SwiftRedux.xcodeproj/project.pbxproj
+++ b/SwiftRedux.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		EE7111DB2235756400532177 /* Redux+Saga+Output.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7111DA2235756300532177 /* Redux+Saga+Output.swift */; };
 		EEC1DE83223DE98300E4AF43 /* Redux+MainThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC1DE82223DE98300E4AF43 /* Redux+MainThread.swift */; };
 		EEC1DE85223E035000E4AF43 /* Redux+MainThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC1DE84223E035000E4AF43 /* Redux+MainThread.swift */; };
+		EEF9E337225668DA0033290C /* Redux+NestedRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF9E336225668DA0033290C /* Redux+NestedRouter.swift */; };
 		EEFD1AAF2234A38D00C3C00E /* SwiftRedux.podspec in Resources */ = {isa = PBXBuildFile; fileRef = EEFD1AAE2234A38D00C3C00E /* SwiftRedux.podspec */; };
 		EEFD1AB12234A53D00C3C00E /* Redux+Awaitable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFD1AB02234A53D00C3C00E /* Redux+Awaitable.swift */; };
 		EEFD1AB32234A81C00C3C00E /* Redux+Awaitable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFD1AB22234A81C00C3C00E /* Redux+Awaitable.swift */; };
@@ -202,6 +203,7 @@
 		EEAABD52221D174B00543DE2 /* ConfirmButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmButton.swift; sourceTree = "<group>"; };
 		EEC1DE82223DE98300E4AF43 /* Redux+MainThread.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+MainThread.swift"; sourceTree = "<group>"; };
 		EEC1DE84223E035000E4AF43 /* Redux+MainThread.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+MainThread.swift"; sourceTree = "<group>"; };
+		EEF9E336225668DA0033290C /* Redux+NestedRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+NestedRouter.swift"; sourceTree = "<group>"; };
 		EEFD1AAE2234A38D00C3C00E /* SwiftRedux.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SwiftRedux.podspec; sourceTree = "<group>"; };
 		EEFD1AB02234A53D00C3C00E /* Redux+Awaitable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+Awaitable.swift"; sourceTree = "<group>"; };
 		EEFD1AB22234A81C00C3C00E /* Redux+Awaitable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+Awaitable.swift"; sourceTree = "<group>"; };
@@ -392,8 +394,9 @@
 		EEAABD39221D174500543DE2 /* Middleware+Router */ = {
 			isa = PBXGroup;
 			children = (
-				EEAABD37221D174500543DE2 /* Redux+Middleware+Router.swift */,
 				EEAABD38221D174500543DE2 /* Protocols+Middleware+Router.swift */,
+				EEAABD37221D174500543DE2 /* Redux+Middleware+Router.swift */,
+				EEF9E336225668DA0033290C /* Redux+NestedRouter.swift */,
 			);
 			path = "Middleware+Router";
 			sourceTree = "<group>";
@@ -800,6 +803,7 @@
 				EEC1DE83223DE98300E4AF43 /* Redux+MainThread.swift in Sources */,
 				EE3A11BF221D7F4A0023B445 /* Redux+Saga+Put.swift in Sources */,
 				EE567CF42236C2C600E907F4 /* Redux+Subscription.swift in Sources */,
+				EEF9E337225668DA0033290C /* Redux+NestedRouter.swift in Sources */,
 				EE3A11C0221D7F4A0023B445 /* Redux+Saga+Empty.swift in Sources */,
 				EE3A11C1221D7F4A0023B445 /* Redux+Preset.swift in Sources */,
 				EE3A11C5221D7F4A0023B445 /* Redux+SimpleStore.swift in Sources */,

--- a/SwiftRedux.xcodeproj/project.pbxproj
+++ b/SwiftRedux.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		EE57167D223F2A23009B8D87 /* Redux+UI+Integration.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57167C223F2A23009B8D87 /* Redux+UI+Integration.swift */; };
 		EE7111D52235474B00532177 /* Redux+Core.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7111D42235474B00532177 /* Redux+Core.swift */; };
 		EE7111DB2235756400532177 /* Redux+Saga+Output.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7111DA2235756300532177 /* Redux+Saga+Output.swift */; };
+		EEB0F2412259FEAC00A7AABF /* ReduxRouterTest+NestedRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB0F2402259FEAC00A7AABF /* ReduxRouterTest+NestedRouter.swift */; };
 		EEC1DE83223DE98300E4AF43 /* Redux+MainThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC1DE82223DE98300E4AF43 /* Redux+MainThread.swift */; };
 		EEC1DE85223E035000E4AF43 /* Redux+MainThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC1DE84223E035000E4AF43 /* Redux+MainThread.swift */; };
 		EEF9E337225668DA0033290C /* Redux+NestedRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF9E336225668DA0033290C /* Redux+NestedRouter.swift */; };
@@ -201,6 +202,7 @@
 		EEAABD50221D174B00543DE2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EEAABD51221D174B00543DE2 /* Redux+Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+Router.swift"; sourceTree = "<group>"; };
 		EEAABD52221D174B00543DE2 /* ConfirmButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmButton.swift; sourceTree = "<group>"; };
+		EEB0F2402259FEAC00A7AABF /* ReduxRouterTest+NestedRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReduxRouterTest+NestedRouter.swift"; sourceTree = "<group>"; };
 		EEC1DE82223DE98300E4AF43 /* Redux+MainThread.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+MainThread.swift"; sourceTree = "<group>"; };
 		EEC1DE84223E035000E4AF43 /* Redux+MainThread.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+MainThread.swift"; sourceTree = "<group>"; };
 		EEF9E336225668DA0033290C /* Redux+NestedRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+NestedRouter.swift"; sourceTree = "<group>"; };
@@ -316,6 +318,7 @@
 				D3300E1021B3713E00779B7F /* ReduxMiddlewareTest.swift */,
 				D30CC2FE205C40F0005B5EA1 /* ReduxPresetTest.swift */,
 				D3803C6421B3E4EB0055467D /* ReduxRouterTest.swift */,
+				EEB0F2402259FEAC00A7AABF /* ReduxRouterTest+NestedRouter.swift */,
 				D335E28E21B6E689000E664D /* ReduxSagaTest.swift */,
 				D334ED5E21B773CA004C538E /* ReduxSagaTest+Effect.swift */,
 				D3E02A4E2257C1C500AA1F41 /* ReduxSagaTest+TakeEffect.swift */,
@@ -831,6 +834,7 @@
 				D3810F5921C0CA550058FA86 /* ReduxLockTest.swift in Sources */,
 				EEFD1AB32234A81C00C3C00E /* Redux+Awaitable.swift in Sources */,
 				D334ED5F21B773CA004C538E /* ReduxSagaTest+Effect.swift in Sources */,
+				EEB0F2412259FEAC00A7AABF /* ReduxRouterTest+NestedRouter.swift in Sources */,
 				D3300E1121B3713E00779B7F /* ReduxMiddlewareTest.swift in Sources */,
 				D3E02A4F2257C1C500AA1F41 /* ReduxSagaTest+TakeEffect.swift in Sources */,
 				EE567CF02236BE0D00E907F4 /* Redux+UniqueID.swift in Sources */,

--- a/SwiftRedux/Middleware+Router/Protocols+Middleware+Router.swift
+++ b/SwiftRedux/Middleware+Router/Protocols+Middleware+Router.swift
@@ -43,11 +43,24 @@ public protocol RouterScreenType: ReduxActionType {}
 ///
 public protocol ReduxRouterType {
   
-  /// The app-specific screen implementation for this router.
-  associatedtype Screen: RouterScreenType
-  
   /// Navigate to a screen.
   ///
-  /// - Parameter screen: A Screen instance.
-  func navigate(_ screen: Screen)
+  /// - Parameter screen: A RouterScreenType instance.
+  func navigate(_ screen: RouterScreenType)
+}
+
+/// Similar to a normal Redux router, but allows navigation method to return
+/// a Bool value to indicate whether it succeeds.
+public protocol VetoableReduxRouterType {
+
+  /// Indicate the priority that this sub-router should receive. The higher
+  /// the priority, the earlier this gets called.
+  var subRouterPriority: Int64 { get }
+  
+  /// Navigate to a screen if possible, and indicate whether the navigation is
+  /// successful.
+  ///
+  /// - Parameter screen: A RouterScreenType instance.
+  /// - Returns: A Bool value.
+  func navigate(_ screen: RouterScreenType) -> Bool
 }

--- a/SwiftRedux/Middleware+Router/Protocols+Middleware+Router.swift
+++ b/SwiftRedux/Middleware+Router/Protocols+Middleware+Router.swift
@@ -51,7 +51,7 @@ public protocol ReduxRouterType {
 
 /// Similar to a normal Redux router, but allows navigation method to return
 /// a Bool value to indicate whether it succeeds.
-public protocol VetoableReduxRouterType {
+public protocol VetoableReduxRouterType: UniqueIDProviderType {
 
   /// Indicate the priority that this sub-router should receive. The higher
   /// the priority, the earlier this gets called.

--- a/SwiftRedux/Middleware+Router/Redux+Middleware+Router.swift
+++ b/SwiftRedux/Middleware+Router/Redux+Middleware+Router.swift
@@ -23,10 +23,10 @@ public typealias Navigate<Screen> = (Screen) -> Void
 ///     dispatch(Screen.login)
 ///     dispatch(Screen.password)
 ///
-public struct RouterMiddleware<State, Screen: RouterScreenType>: MiddlewareProviderType {
-  private let _navigate: Navigate<Screen>
+public struct RouterMiddleware<State>: MiddlewareProviderType {
+  private let _navigate: Navigate<RouterScreenType>
   
-  public init<R>(router: R) where R: ReduxRouterType, R.Screen == Screen {
+  public init<R>(router: R) where R: ReduxRouterType {
     self._navigate = router.navigate
   }
   
@@ -36,7 +36,7 @@ public struct RouterMiddleware<State, Screen: RouterScreenType>: MiddlewareProvi
         let newWrapperId = "\(wrapper.identifier)-router"
         
         return DispatchWrapper(newWrapperId) {action in
-          if let screen = action as? Screen {
+          if let screen = action as? RouterScreenType {
             // Force-navigate on the main thread.
             DispatchQueue.main.async {self._navigate(screen)}
           }

--- a/SwiftRedux/Middleware+Router/Redux+NestedRouter.swift
+++ b/SwiftRedux/Middleware+Router/Redux+NestedRouter.swift
@@ -1,0 +1,91 @@
+//
+//  Redux+NestedRouter.swift
+//  SwiftRedux
+//
+//  Created by Viethai Pham on 5/4/19.
+//  Copyright © 2019 Hai Pham. All rights reserved.
+//
+
+/// Nested Redux router that keeps a list of sub-routers sorted by priority.
+/// Every time a screen arrives, iterate through the list and stop at the first
+/// sub-router that succeeds in navigating.
+public final class NestedRouter {
+  public typealias UniqueID = UniqueIDProviderType.UniqueID
+  
+  /// Default screen for nested router.
+  ///
+  /// - registerSubRouter: Register a sub-router.
+  /// - unregisterSubRouter: Unregister a sub-router.
+  private enum DefaultScreen: RouterScreenType {
+    case registerSubRouter(VetoableReduxRouterType)
+    case unregisterSubRouter(UniqueID)
+  }
+  
+  /// Register a sub-router.
+  ///
+  /// - Parameter subRouter: A sub-router instance.
+  /// - Returns: A router screen instance.
+  public static func register(subRouter: VetoableReduxRouterType) -> RouterScreenType {
+    return DefaultScreen.registerSubRouter(subRouter)
+  }
+  
+  /// Unregister a sub-router.
+  ///
+  /// - Parameter subRouterID: A sub-router ID.
+  /// - Returns: A router screen instance.
+  public static func unregister(subRouterID: UniqueID) -> RouterScreenType {
+    return DefaultScreen.unregisterSubRouter(subRouterID)
+  }
+  
+  /// Unregister a sub-router.
+  ///
+  /// - Parameter subRouter: A sub-router instance.
+  /// - Returns: A router screen instance.
+  public static func unregister(subRouter: VetoableReduxRouterType) -> RouterScreenType {
+    return self.unregister(subRouterID: subRouter.uniqueID)
+  }
+  
+  /// Create a new Redux router.
+  ///
+  /// - Returns: A Redux router instance.
+  public static func create() -> ReduxRouterType {
+    return NestedRouter()
+  }
+  
+  private let _lock: ReadWriteLockType
+  private var _subRouters: [VetoableReduxRouterType]
+  
+  private init() {
+    self._lock = ReadWriteLock()
+    self._subRouters = []
+  }
+}
+
+// MARK: - ReduxRouterType
+extension NestedRouter: ReduxRouterType {
+  public func navigate(_ screen: RouterScreenType) {
+    switch screen {
+    case let screen as DefaultScreen:
+      switch screen {
+      case .registerSubRouter(let s):
+        self._lock.modify {
+          guard !self._subRouters.contains(where: {$0.uniqueID == s.uniqueID}) else { return }
+          self._subRouters.insert(s, at: 0)
+          self._subRouters.sort(by: {$0.subRouterPriority > $1.subRouterPriority})
+        }
+        
+      case .unregisterSubRouter(let id):
+        self._lock.modify {
+          if let index = self._subRouters.firstIndex(where: {$0.uniqueID == id}) {
+            self._subRouters.remove(at: index)
+          }
+        }
+      }
+      
+    default:
+      return self._lock.access {
+        _ = self._subRouters.first(where: {$0.navigate(screen)})
+      }
+    }
+  }
+}

--- a/SwiftReduxTests/ReduxRouterTest+NestedRouter.swift
+++ b/SwiftReduxTests/ReduxRouterTest+NestedRouter.swift
@@ -1,0 +1,121 @@
+//
+//  ReduxRouterTest+NestedRouter.swift
+//  SwiftReduxTests
+//
+//  Created by Viethai Pham on 7/4/19.
+//  Copyright © 2019 Hai Pham. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftRedux
+
+public final class NestedReduxRouterTest: XCTestCase {
+  final class SubRouter: VetoableReduxRouterType {
+    let subRouterPriority: Int64
+    private(set) var navigationCount: Int64
+    private let _navigate: (RouterScreenType) -> Bool
+    
+    var uniqueID: UniqueID = DefaultUniqueIDProvider.next()
+    
+    init(_ subRouterPriority: Int64,
+         _ navigate: @escaping (RouterScreenType) -> Bool = {_ in true}) {
+      self.subRouterPriority = subRouterPriority
+      self.navigationCount = 0
+      self._navigate = navigate
+    }
+    
+    func navigate(_ screen: RouterScreenType) -> Bool {
+      if (self._navigate(screen)) {
+        OSAtomicIncrement64(&self.navigationCount)
+        return true
+      }
+      
+      return false
+    }
+  }
+  
+  enum Screen: RouterScreenType {
+    case instance(String)
+  }
+  
+  public func test_sendingRegisterOrUnregister_shouldAddOrRemoveSubRouter() {
+    /// Setup
+    let iteration = 1000
+    let dispatchGroup = DispatchGroup()
+    let router = NestedRouter.create()
+    let subRouter = SubRouter(0)
+    
+    /// When
+    (0..<iteration).forEach({_ in dispatchGroup.enter()})
+    
+    (0..<iteration).forEach({_ in
+      DispatchQueue.global(qos: .background).async {
+        router.navigate(NestedRouter.register(subRouter: subRouter))
+        dispatchGroup.leave()
+      }
+    })
+    
+    dispatchGroup.wait()
+    
+    (0..<iteration).forEach({_ in dispatchGroup.enter()})
+    
+    (0..<iteration).forEach({_ in DispatchQueue.global(qos: .background).async {
+      router.navigate(Screen.instance(""))
+      dispatchGroup.leave()
+    }})
+    
+    dispatchGroup.wait()
+    
+    router.navigate(NestedRouter.unregister(subRouter: subRouter))
+    
+    (0..<iteration).forEach({_ in dispatchGroup.enter()})
+    
+    (0..<iteration).forEach({_ in
+      DispatchQueue.global(qos: .background).async {
+        router.navigate(Screen.instance(""))
+        dispatchGroup.leave()
+      }
+    })
+    
+    dispatchGroup.wait()
+    
+    /// Then
+    XCTAssertEqual(subRouter.navigationCount, Int64(iteration))
+  }
+  
+  public func test_navigatingToScreen_shouldGoThroughSubRoutersSequentially() {
+    /// Setup
+    let iteration = 1000
+    let otherSubRouters = (0..<iteration).map({SubRouter(Int64($0))})
+    var mainNavigationCount: Int64 = 0
+    
+    let mainSubRouter = SubRouter(Int64(iteration + 1)) {_ in
+      if Bool.random() {
+        OSAtomicIncrement64(&mainNavigationCount)
+        return true
+      } else {
+        return false
+      }
+    }
+    
+    let router = NestedRouter.create()
+    otherSubRouters.map(NestedRouter.register).forEach(router.navigate)
+    router.navigate(NestedRouter.register(subRouter: mainSubRouter))
+    
+    /// When
+    let dispatchGroup = DispatchGroup()
+    (0..<iteration).forEach({_ in dispatchGroup.enter()})
+    
+    (0..<iteration).forEach({_ in
+      DispatchQueue.global(qos: .background).async {
+        router.navigate(Screen.instance(""))
+        dispatchGroup.leave()
+      }
+    })
+    
+    dispatchGroup.wait()
+    
+    /// Then
+    XCTAssertEqual(mainSubRouter.navigationCount, mainNavigationCount)
+  }
+}

--- a/SwiftReduxTests/ReduxRouterTest.swift
+++ b/SwiftReduxTests/ReduxRouterTest.swift
@@ -57,13 +57,11 @@ extension ReduxRouterTest {
   }
   
   final class ReduxRouter: ReduxRouterType {
-    typealias Screen = ReduxRouterTest.Screen
-    
     var history: [Screen] = []
     var navigateCallback: ((Int) -> Void)?
     
-    func navigate(_ screen: ReduxRouterTest.Screen) {
-      self.history.append(screen)
+    func navigate(_ screen: RouterScreenType) {
+      self.history.append(screen as! Screen)
       self.navigateCallback?(self.history.count)
     }
   }


### PR DESCRIPTION
Add `NestedRouter` to navigate sequentially.

A `NestedRouter` comprises a sorted `Array` of `VetoableReduxRouterType` - mini-routers that can optionally navigate to a `RouterScreenType` (as indicated by a `Bool` value returned by their `navigate` method). Every time a `RouterScreenType` arrives, the `NestedRouter` goes through the `Array` sequentially until it encounters the first sub-router that successfully navigates.

Register/unregister a `VetoableReduxRouterType` like so:

```swift
dispatch(NestedRouter.register(subRouter: self))
dispatch(NestedRouter.unregister(subRouter: self))
```