### PR TITLE
Saga monitor

### DIFF
--- a/SwiftRedux.xcodeproj/project.pbxproj
+++ b/SwiftRedux.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		EE567CF62236C94A00E907F4 /* Redux+Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE567CF52236C94A00E907F4 /* Redux+Subscription.swift */; };
 		EE57167D223F2A23009B8D87 /* Redux+UI+Integration.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57167C223F2A23009B8D87 /* Redux+UI+Integration.swift */; };
 		EE6DDCF6226790D300288867 /* Redux+SagaMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6DDCF5226790D300288867 /* Redux+SagaMonitor.swift */; };
+		EE6DDCF82267964100288867 /* Redux+SagaMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6DDCF72267964100288867 /* Redux+SagaMonitor.swift */; };
 		EE7111D52235474B00532177 /* Redux+Core.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7111D42235474B00532177 /* Redux+Core.swift */; };
 		EE7111DB2235756400532177 /* Redux+Saga+Output.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7111DA2235756300532177 /* Redux+Saga+Output.swift */; };
 		EEB0F2412259FEAC00A7AABF /* ReduxRouterTest+NestedRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB0F2402259FEAC00A7AABF /* ReduxRouterTest+NestedRouter.swift */; };
@@ -148,6 +149,7 @@
 		EE567CF52236C94A00E907F4 /* Redux+Subscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+Subscription.swift"; sourceTree = "<group>"; };
 		EE57167C223F2A23009B8D87 /* Redux+UI+Integration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+UI+Integration.swift"; sourceTree = "<group>"; };
 		EE6DDCF5226790D300288867 /* Redux+SagaMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+SagaMonitor.swift"; sourceTree = "<group>"; };
+		EE6DDCF72267964100288867 /* Redux+SagaMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+SagaMonitor.swift"; sourceTree = "<group>"; };
 		EE7111D42235474B00532177 /* Redux+Core.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+Core.swift"; sourceTree = "<group>"; };
 		EE7111DA2235756300532177 /* Redux+Saga+Output.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Redux+Saga+Output.swift"; sourceTree = "<group>"; };
 		EEAABD0B221D174500543DE2 /* Redux+SimpleStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+SimpleStore.swift"; sourceTree = "<group>"; };
@@ -324,6 +326,7 @@
 				D335E28E21B6E689000E664D /* ReduxSagaTest.swift */,
 				D334ED5E21B773CA004C538E /* ReduxSagaTest+Effect.swift */,
 				D3E02A4E2257C1C500AA1F41 /* ReduxSagaTest+TakeEffect.swift */,
+				EE6DDCF72267964100288867 /* Redux+SagaMonitor.swift */,
 			);
 			path = SwiftReduxTests;
 			sourceTree = "<group>";
@@ -843,6 +846,7 @@
 				D3E02A4F2257C1C500AA1F41 /* ReduxSagaTest+TakeEffect.swift in Sources */,
 				EE567CF02236BE0D00E907F4 /* Redux+UniqueID.swift in Sources */,
 				EEC1DE85223E035000E4AF43 /* Redux+MainThread.swift in Sources */,
+				EE6DDCF82267964100288867 /* Redux+SagaMonitor.swift in Sources */,
 				EE7111D52235474B00532177 /* Redux+Core.swift in Sources */,
 				EE567CF62236C94A00E907F4 /* Redux+Subscription.swift in Sources */,
 			);

--- a/SwiftRedux.xcodeproj/project.pbxproj
+++ b/SwiftRedux.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		EE567CF42236C2C600E907F4 /* Redux+Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE567CF32236C2C600E907F4 /* Redux+Subscription.swift */; };
 		EE567CF62236C94A00E907F4 /* Redux+Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE567CF52236C94A00E907F4 /* Redux+Subscription.swift */; };
 		EE57167D223F2A23009B8D87 /* Redux+UI+Integration.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57167C223F2A23009B8D87 /* Redux+UI+Integration.swift */; };
+		EE6DDCF6226790D300288867 /* Redux+SagaMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6DDCF5226790D300288867 /* Redux+SagaMonitor.swift */; };
 		EE7111D52235474B00532177 /* Redux+Core.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7111D42235474B00532177 /* Redux+Core.swift */; };
 		EE7111DB2235756400532177 /* Redux+Saga+Output.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7111DA2235756300532177 /* Redux+Saga+Output.swift */; };
 		EEB0F2412259FEAC00A7AABF /* ReduxRouterTest+NestedRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB0F2402259FEAC00A7AABF /* ReduxRouterTest+NestedRouter.swift */; };
@@ -146,6 +147,7 @@
 		EE567CF32236C2C600E907F4 /* Redux+Subscription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Redux+Subscription.swift"; sourceTree = "<group>"; };
 		EE567CF52236C94A00E907F4 /* Redux+Subscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+Subscription.swift"; sourceTree = "<group>"; };
 		EE57167C223F2A23009B8D87 /* Redux+UI+Integration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+UI+Integration.swift"; sourceTree = "<group>"; };
+		EE6DDCF5226790D300288867 /* Redux+SagaMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+SagaMonitor.swift"; sourceTree = "<group>"; };
 		EE7111D42235474B00532177 /* Redux+Core.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+Core.swift"; sourceTree = "<group>"; };
 		EE7111DA2235756300532177 /* Redux+Saga+Output.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Redux+Saga+Output.swift"; sourceTree = "<group>"; };
 		EEAABD0B221D174500543DE2 /* Redux+SimpleStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+SimpleStore.swift"; sourceTree = "<group>"; };
@@ -390,6 +392,7 @@
 				EEAABD21221D174500543DE2 /* Redux+Saga+Take.swift */,
 				EEAABD26221D174500543DE2 /* Redux+Saga+Take+Option.swift */,
 				EEAABD32221D174500543DE2 /* Redux+Saga+Unwrap.swift */,
+				EE6DDCF5226790D300288867 /* Redux+SagaMonitor.swift */,
 			);
 			path = "Middleware+Saga";
 			sourceTree = "<group>";
@@ -812,6 +815,7 @@
 				EE3A11C5221D7F4A0023B445 /* Redux+SimpleStore.swift in Sources */,
 				EE3A11C6221D7F4A0023B445 /* Redux+Store.swift in Sources */,
 				EE3A11C7221D7F4A0023B445 /* Redux+PropInjector.swift in Sources */,
+				EE6DDCF6226790D300288867 /* Redux+SagaMonitor.swift in Sources */,
 				EE3A11C8221D7F4A0023B445 /* Redux+PropContainer.swift in Sources */,
 				EE3A11C9221D7F4A0023B445 /* Redux+PropMapper.swift in Sources */,
 				EE3A11CB221D7F4A0023B445 /* Redux+Props.swift in Sources */,

--- a/SwiftRedux/Core/Protocols.swift
+++ b/SwiftRedux/Core/Protocols.swift
@@ -15,9 +15,16 @@ import SwiftFP
 /// data as enum arguments.
 public protocol ReduxActionType {}
 
+/// Represents an object that provides an action dispatcher.
+public protocol ReduxDispatcherProviderType {
+
+  /// Dispatch an action and notify listeners.
+  var dispatch: AwaitableReduxDispatcher { get }
+}
+
 /// This represents a Redux store that can dispatch actions to mutate internal
 /// state and broadcast state updates to subscribers.
-public protocol ReduxStoreType: ReduxUnsubscriberProviderType {
+public protocol ReduxStoreType: ReduxDispatcherProviderType, ReduxUnsubscriberProviderType {
   
   /// The app-specific state type. For example:
   ///
@@ -32,9 +39,6 @@ public protocol ReduxStoreType: ReduxUnsubscriberProviderType {
   
   /// Get the last state instance.
   var lastState: ReduxStateGetter<State> { get }
-  
-  /// Dispatch an action and notify listeners.
-  var dispatch: AwaitableReduxDispatcher { get }
   
   /// Set up state callback so that every time a new state arrives, call the
   /// callback function.

--- a/SwiftRedux/Middleware+Saga/Protocols+Saga.swift
+++ b/SwiftRedux/Middleware+Saga/Protocols+Saga.swift
@@ -89,7 +89,7 @@ public protocol SagaMonitorType: ReduxDispatcherProviderType {
   ///   - uniqueID: A unique ID value.
   ///   - dispatch: An action dispatcher instance.
   func addDispatcher(_ uniqueID: UniqueIDProviderType.UniqueID,
-                     _ dispatch: AwaitableReduxDispatcher)
+                     _ dispatch: @escaping AwaitableReduxDispatcher)
   
   /// Remove an action dispatcher at a unique ID.
   ///

--- a/SwiftRedux/Middleware+Saga/Protocols+Saga.swift
+++ b/SwiftRedux/Middleware+Saga/Protocols+Saga.swift
@@ -77,3 +77,22 @@ public extension SagaEffectType where Self: SingleSagaEffectType {
     return try self.invoke(input).await()
   }
 }
+
+/// Monitors all Saga outputs and call each stored output's action dispatcher
+/// every time an action arrives. This is the only way to notify all output
+/// action dispatchers, no matter how nested it is.
+public protocol SagaMonitorType: ReduxDispatcherProviderType {
+
+  /// Store an action dispatcher with a unique ID.
+  ///
+  /// - Parameters:
+  ///   - uniqueID: A unique ID value.
+  ///   - dispatch: An action dispatcher instance.
+  func addDispatcher(_ uniqueID: UniqueIDProviderType.UniqueID,
+                     _ dispatch: AwaitableReduxDispatcher)
+  
+  /// Remove an action dispatcher at a unique ID.
+  ///
+  /// - Parameter uniqueID: A unique ID value.
+  func removeDispatcher(_ uniqueID: UniqueIDProviderType.UniqueID)
+}

--- a/SwiftRedux/Middleware+Saga/Redux+SagaMonitor.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+SagaMonitor.swift
@@ -1,0 +1,41 @@
+//
+//  Redux+SagaMonitor.swift
+//  SwiftRedux
+//
+//  Created by Viethai Pham on 18/4/19.
+//  Copyright © 2019 Hai Pham. All rights reserved.
+//
+
+/// Default Saga monitor implementation.
+public final class SagaMonitor {
+  private typealias UniqueID = UniqueIDProviderType.UniqueID
+  private var _dispatchers: [UniqueID : AwaitableReduxDispatcher]
+  private let _lock: ReadWriteLockType
+  
+  public lazy private(set) var dispatch: AwaitableReduxDispatcher = {action in
+    self._lock.modify {
+      self._dispatchers.forEach {_, value in _ = value(action) }
+      return EmptyAwaitable.instance
+    }
+  }
+  
+  public init() {
+    self._dispatchers = [:]
+    self._lock = ReadWriteLock()
+  }
+}
+
+// MARK: - ReduxDispatcherProviderType
+extension SagaMonitor: ReduxDispatcherProviderType {}
+
+// MARK: - SagaMonitorType
+extension SagaMonitor: SagaMonitorType {
+  public func addDispatcher(_ uniqueID: UniqueIDProviderType.UniqueID,
+                            _ dispatch: @escaping AwaitableReduxDispatcher) {
+    self._lock.modify { self._dispatchers[uniqueID] = dispatch }
+  }
+  
+  public func removeDispatcher(_ uniqueID: Int64) {
+    self._lock.modify { _ = self._dispatchers.removeValue(forKey: uniqueID) }
+  }
+}

--- a/SwiftReduxTests/Redux+SagaMonitor.swift
+++ b/SwiftReduxTests/Redux+SagaMonitor.swift
@@ -1,0 +1,63 @@
+//
+//  Redux+SagaMonitor.swift
+//  SwiftReduxTests
+//
+//  Created by Viethai Pham on 18/4/19.
+//  Copyright © 2019 Hai Pham. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftRedux
+
+public final class ReduxSagaMonitorTest: XCTestCase {
+  public func test_dispatchingActions_shouldInvokeStoredDispatchers() throws {
+    /// Setup
+    let monitor = SagaMonitor()
+    var dispatchedCount: Int64 = 0
+    let iteration = 1000
+    let dispatchGroup = DispatchGroup()
+    
+    /// When - add dispatchers
+    (0..<iteration).forEach {_ in dispatchGroup.enter() }
+    
+    (0..<iteration).forEach {i in
+      DispatchQueue.global(qos: .background).async {
+        monitor.addDispatcher(Int64(i)) {_ in
+          OSAtomicIncrement64(&dispatchedCount)
+          return EmptyAwaitable.instance
+        }
+        
+        dispatchGroup.leave()
+      }
+    }
+    
+    dispatchGroup.wait()
+    
+    /// When - remove dispatchers
+    (0..<(iteration / 2)).forEach {_ in dispatchGroup.enter() }
+    
+    (0..<(iteration / 2)).forEach {i in
+      DispatchQueue.global(qos: .background).async {
+        monitor.removeDispatcher(Int64(i))
+        dispatchGroup.leave()
+      }
+    }
+    
+    dispatchGroup.wait()
+    
+    /// When - dispatch actions
+    (0..<iteration).forEach {_ in dispatchGroup.enter() }
+    
+    (0..<iteration).forEach {i in
+      DispatchQueue.global(qos: .background).async {
+        _ = try! monitor.dispatch(DefaultAction.noop).await()
+        dispatchGroup.leave()
+      }
+    }
+    
+    dispatchGroup.wait()
+    
+    /// Then
+    XCTAssertEqual(Int(dispatchedCount), iteration / 2 * iteration)
+  }
+}


### PR DESCRIPTION
A `SagaMonitor` is a centralized action dispatcher that invokes all stored action dispatchers. We use it to ensure `SagaOutput` instances, no matter how nested, still have their dispatchers called every time an action arrives.

Integration of `SagaMonitor` and `SagaOutput` is not in this MR for simplicity.