### PR TITLE
Batch awaitable

### DIFF
--- a/SwiftRedux/Core/Redux+Awaitable.swift
+++ b/SwiftRedux/Core/Redux+Awaitable.swift
@@ -133,3 +133,21 @@ public final class AsyncAwaitable<Result> : Awaitable<Result> {
     }
   }
 }
+
+/// An awaitable job that batches the await results from an Array of children
+/// awaitables. The result will be delivered in-order.
+public final class BatchAwaitable<SingleResult> : Awaitable<[SingleResult]> {
+  private let awaitables: [Awaitable<SingleResult>]
+  
+  public init(_ awaitables: [Awaitable<SingleResult>]) {
+    self.awaitables = awaitables
+  }
+  
+  override public func await() throws -> [SingleResult] {
+    return try self.awaitables.map({try $0.await()})
+  }
+  
+  override public func await(timeoutMillis: Double) throws -> [SingleResult] {
+    return try self.awaitables.map({try $0.await(timeoutMillis: timeoutMillis)})
+  }
+}

--- a/SwiftRedux/Middleware+Saga/Redux+SagaMonitor.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+SagaMonitor.swift
@@ -14,8 +14,9 @@ public final class SagaMonitor {
   
   public lazy private(set) var dispatch: AwaitableReduxDispatcher = {action in
     self._lock.modify {
-      self._dispatchers.forEach {_, value in _ = value(action) }
-      return EmptyAwaitable.instance
+      let awaitables = self._dispatchers.map({_, value in value(action)})
+      let results = try? BatchAwaitable(awaitables).await()
+      return JustAwaitable(results as Any)
     }
   }
   

--- a/SwiftReduxTests/Redux+Awaitable.swift
+++ b/SwiftReduxTests/Redux+Awaitable.swift
@@ -142,9 +142,11 @@ class AwaitableTests: XCTestCase {
     })
       
     /// When
-    let results = try batchJob.await()
+    let results1 = try batchJob.await()
+    let results2 = try batchJob.await(timeoutMillis: 1000)
     
     /// Then
-    XCTAssertEqual(results, (0..<iteration).map({$0}))
+    XCTAssertEqual(results1, (0..<iteration).map({$0}))
+    XCTAssertEqual(results1, results2)
   }
 }

--- a/SwiftReduxTests/Redux+SagaMonitor.swift
+++ b/SwiftReduxTests/Redux+SagaMonitor.swift
@@ -60,4 +60,20 @@ public final class ReduxSagaMonitorTest: XCTestCase {
     /// Then
     XCTAssertEqual(Int(dispatchedCount), iteration / 2 * iteration)
   }
+  
+  public func test_awaitingDispatch_shouldEnsureAllDispatchersFinish() throws {
+    /// Setup
+    let iteration = 100
+    let monitor = SagaMonitor()
+    
+    (0..<iteration).forEach({i in
+      monitor.addDispatcher(Int64(i)) {_ in JustAwaitable(i)}
+    })
+    
+    /// When
+    let results = try monitor.dispatch(DefaultAction.noop).await()
+    
+    /// Then
+    XCTAssertEqual((results as! [Int]).sorted(), (0..<iteration).map({$0}))
+  }
 }


### PR DESCRIPTION
Add `BatchAwaitable` to wait for all stored `Awaitable`. `SagaMonitor` now uses `BatchAwaitable` to ensure all dispatch actions are completed and dispatch results are collected.