### PR TITLE
Automatically generate uniqueID in static props

### DIFF
--- a/SwiftRedux-Demo/ConfirmButton.swift
+++ b/SwiftRedux-Demo/ConfirmButton.swift
@@ -11,7 +11,6 @@ import SafeNest
 import UIKit
 
 final class ConfirmButton: UIButton {
-  let uniqueID = DefaultUniqueIDProvider.next()
   var staticProps: StaticProps!
   var reduxProps: ReduxProps?
   

--- a/SwiftRedux-Demo/RootController.swift
+++ b/SwiftRedux-Demo/RootController.swift
@@ -12,7 +12,6 @@ import UIKit
 final class RootController: UIViewController {
   @IBOutlet private weak var viewController1: UIButton!
   
-  let uniqueID = DefaultUniqueIDProvider.next()
   var staticProps: StaticProps!
   var reduxProps: ReduxProps?
   

--- a/SwiftRedux-Demo/TableCell.swift
+++ b/SwiftRedux-Demo/TableCell.swift
@@ -13,7 +13,6 @@ final class TableCell: UITableViewCell {
   @IBOutlet private weak var textInput: UITextField!
   
   var textIndex: Int?
-  let uniqueID = DefaultUniqueIDProvider.next()
   var staticProps: StaticProps!
   
   var reduxProps: ReduxProps? {

--- a/SwiftRedux-Demo/ViewController1.swift
+++ b/SwiftRedux-Demo/ViewController1.swift
@@ -21,8 +21,6 @@ final class ViewController1: UIViewController {
   @IBOutlet private weak var clearButton: ConfirmButton!
   @IBOutlet private weak var textTable: UITableView!
   
-  let uniqueID = DefaultUniqueIDProvider.next()
-  
   public var staticProps: StaticProps! {
     didSet {
       self.staticProps?.injector.injectProps(view: self.clearButton, outProps: ())

--- a/SwiftRedux-MusicDemo/iTunesController.swift
+++ b/SwiftRedux-MusicDemo/iTunesController.swift
@@ -16,8 +16,6 @@ public final class iTunesController: UIViewController {
   @IBOutlet weak var progressIndicatorLeading: NSLayoutConstraint!
   @IBOutlet weak var progressIndicatorTrailing: NSLayoutConstraint!
   
-  public let uniqueID = DefaultUniqueIDProvider.next()
-  
   public var staticProps: StaticProps!
   
   public var reduxProps: ReduxProps? {

--- a/SwiftRedux-MusicDemo/iTunesTrackCell.swift
+++ b/SwiftRedux-MusicDemo/iTunesTrackCell.swift
@@ -15,8 +15,6 @@ public final class iTunesTrackCell: UITableViewCell {
   @IBOutlet private weak var artistName: UILabel!
   @IBOutlet private weak var rootButton: UIButton!
   
-  public let uniqueID = DefaultUniqueIDProvider.next()
-  
   public var staticProps: StaticProps!
   
   public var reduxProps: ReduxProps? {

--- a/SwiftRedux.xcodeproj/project.pbxproj
+++ b/SwiftRedux.xcodeproj/project.pbxproj
@@ -115,6 +115,13 @@
 			remoteGlobalIDString = D3943ECD1FA32D5600898233;
 			remoteInfo = SwiftRedux;
 		};
+		D357E2BA226E562C00752B71 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D3943EC51FA32D5600898233 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D3943ECD1FA32D5600898233;
+			remoteInfo = SwiftRedux;
+		};
 		D3943ED91FA32D5600898233 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D3943EC51FA32D5600898233 /* Project object */;
@@ -617,6 +624,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				D357E2BB226E562C00752B71 /* PBXTargetDependency */,
 			);
 			name = "SwiftRedux-MusicDemo";
 			productName = "SwiftRedux-MusicDemo";
@@ -926,6 +934,11 @@
 			isa = PBXTargetDependency;
 			target = D3943ECD1FA32D5600898233 /* SwiftRedux */;
 			targetProxy = D350C3741FA390C40040556F /* PBXContainerItemProxy */;
+		};
+		D357E2BB226E562C00752B71 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D3943ECD1FA32D5600898233 /* SwiftRedux */;
+			targetProxy = D357E2BA226E562C00752B71 /* PBXContainerItemProxy */;
 		};
 		D3943EDA1FA32D5600898233 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/SwiftRedux/UI+Test/Redux+MockProps.swift
+++ b/SwiftRedux/UI+Test/Redux+MockProps.swift
@@ -15,6 +15,6 @@ public final class MockStaticProps<State>: StaticPropContainer<State> {
 
   /// This initializer can be used to construct test static props.
   convenience public init(injector: PropInjector<State>) {
-    self.init(injector, ReduxSubscription.noop)
+    self.init(DefaultUniqueIDProvider.next(), injector, ReduxSubscription.noop)
   }
 }

--- a/SwiftRedux/UI/Redux+PropContainer.swift
+++ b/SwiftRedux/UI/Redux+PropContainer.swift
@@ -43,6 +43,12 @@ public protocol PropContainerType: class, UniqueIDProviderType {
   var reduxProps: ReduxProps? { get set }
 }
 
+extension PropContainerType where Self: UniqueIDProviderType {
+  public var uniqueID: Self.UniqueID {
+    return self.staticProps.uniqueID
+  }
+}
+
 /// Generally the Redux view also implements the prop mapper protocol, so in
 /// this case we can define some default generics.
 public extension PropContainerType where Self: PropMapperType {

--- a/SwiftRedux/UI/Redux+PropInjector.swift
+++ b/SwiftRedux/UI/Redux+PropInjector.swift
@@ -151,11 +151,12 @@ public class PropInjector<GlobalState>: PropInjectorType {
     // state to a subscriber on subscription (so at least the injection is
     // triggered once).
     setProps(cv, self.store.lastState())
+    let uniqueID = DefaultUniqueIDProvider.next()
     
     let subscription = self.store
-      .subscribeState(cv.uniqueID) {[weak cv] state in setProps(cv, state)}
+      .subscribeState(uniqueID) {[weak cv] state in setProps(cv, state)}
     
-    cv.staticProps = StaticPropContainer(self, subscription)
+    cv.staticProps = StaticPropContainer(uniqueID, self, subscription)
     return subscription
   }
 }

--- a/SwiftRedux/UI/Redux+Props.swift
+++ b/SwiftRedux/UI/Redux+Props.swift
@@ -7,7 +7,8 @@
 //
 
 /// Static props container.
-public class StaticPropContainer<State> {
+public class StaticPropContainer<State> : UniqueIDProviderType {
+  public let uniqueID: UniqueID
   
   /// The injector instance used to inject Redux props into compatible views.
   public let injector: PropInjector<State>
@@ -15,7 +16,10 @@ public class StaticPropContainer<State> {
   /// Remember to unsubscribe before re-injecting again.
   let subscription: ReduxSubscription
   
-  internal init(_ injector: PropInjector<State>, _ subscription: ReduxSubscription) {
+  public init(_ uniqueID: UniqueID,
+              _ injector: PropInjector<State>,
+              _ subscription: ReduxSubscription) {
+    self.uniqueID = uniqueID
     self.injector = injector
     self.subscription = subscription
   }

--- a/SwiftReduxTests/Redux+UI+Integration.swift
+++ b/SwiftReduxTests/Redux+UI+Integration.swift
@@ -30,7 +30,6 @@ public final class ReduxUIIntegrationTest: XCTestCase {
       typealias OutProps = ()
       typealias StateProps = Int
       typealias ActionProps = ()
-      let uniqueID = DefaultUniqueIDProvider.next()
       
       var staticProps: StaticProps!
       

--- a/SwiftReduxTests/Redux+UI.swift
+++ b/SwiftReduxTests/Redux+UI.swift
@@ -49,6 +49,7 @@ extension ReduxUITests {
     XCTAssertEqual(self.store.lastState().counter, self.iterations * 2)
     XCTAssertEqual(self.store.unsubscribeCount, 1)
     XCTAssertTrue(view.staticProps?.injector is PropInjector<TestState>)
+    XCTAssertEqual(view.uniqueID, view.staticProps?.uniqueID)
     checkOthers(view)
   
     // Check if re-injecting would unsubscribe from the previous subscription.
@@ -192,7 +193,6 @@ extension ReduxUITests {
 extension ReduxUITests {
   final class TestViewController: UIViewController {
     deinit { print("Deinit \(self)"); self.onDeinit?() }
-    let uniqueID = DefaultUniqueIDProvider.next()
     var staticProps: StaticPropContainer<StateProps>!
     
     var reduxProps: ReduxProps? {
@@ -210,7 +210,6 @@ extension ReduxUITests {
   
   final class TestView: UIView {
     deinit { print("Deinit \(self)"); self.onDeinit?() }
-    let uniqueID = DefaultUniqueIDProvider.next()
     var staticProps: StaticPropContainer<StateProps>!
     
     var reduxProps: ReduxProps? {


### PR DESCRIPTION
Automatically generate `uniqueID` in `StaticProps` so that `PropContainerType` does not need to implement `uniqueID` by itself.