### PR TITLE
Middleware input dispatcher

### DIFF
--- a/SwiftRedux/Middleware+Router/Redux+Middleware+Router.swift
+++ b/SwiftRedux/Middleware+Router/Redux+Middleware+Router.swift
@@ -37,7 +37,7 @@ public struct RouterMiddleware<State> {
             DispatchQueue.main.async {router.navigate(screen)}
           }
           
-          return wrapper.dispatch(action)
+          return wrapper.dispatcher(action)
         }
       }
     }

--- a/SwiftRedux/Middleware+Saga/Redux+Middleware+Saga.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Middleware+Saga.swift
@@ -31,13 +31,13 @@ public struct SagaMiddleware<State> {
     
     return {wrapper in
       let lastState = input.lastState
-      let sagaInput = SagaInput(monitor, lastState, wrapper.dispatch)
+      let sagaInput = SagaInput(monitor, lastState, input.dispatcher)
       let sagaOutputs = effects.map({$0.invoke(sagaInput)})
       let newWrapperId = "\(wrapper.identifier)-saga"
       sagaOutputs.forEach({$0.subscribeByDefault({_ in})})
       
       return DispatchWrapper(newWrapperId) {action in
-        let dispatchResult = try! wrapper.dispatch(action).await()
+        let dispatchResult = try! wrapper.dispatcher(action).await()
         _ = try! monitor.dispatch(action).await()
         sagaOutputs.forEach({_ = $0.onAction(action)})
         return JustAwaitable(dispatchResult)

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Put.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Put.swift
@@ -28,7 +28,7 @@ public final class PutEffect<P>: SagaEffect<Any> {
     return _param.invoke(input)
       .map(self._actionCreator)
       .observeOn(ConcurrentDispatchQueueScheduler(queue: self._dispatchQueue))
-      .map(input.dispatch)
+      .map(input.dispatcher)
   }
   
   /// Await for the first result that arrives. Since this can never throw an

--- a/SwiftRedux/Middleware+Saga/Redux+Saga.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga.swift
@@ -36,21 +36,21 @@ public enum SagaError: LocalizedError {
 public struct SagaInput {
   let monitor: SagaMonitorType
   let lastState: ReduxStateGetter<Any>
-  let dispatch: AwaitableReduxDispatcher
+  let dispatcher: AwaitableReduxDispatcher
   
   init(_ monitor: SagaMonitorType,
        _ lastState: @escaping ReduxStateGetter<Any>,
-       _ dispatch: @escaping AwaitableReduxDispatcher) {
+       _ dispatcher: @escaping AwaitableReduxDispatcher) {
     self.monitor = monitor
     self.lastState = lastState
-    self.dispatch = dispatch
+    self.dispatcher = dispatcher
   }
   
   init(_ monitor: SagaMonitorType,
        _ lastState: @escaping ReduxStateGetter<Any>,
-       _ dispatch: @escaping ReduxDispatcher = {_ in}) {
+       _ dispatcher: @escaping ReduxDispatcher = {_ in}) {
     self.monitor = monitor
     self.lastState = lastState
-    self.dispatch = { dispatch($0); return EmptyAwaitable.instance }
+    self.dispatcher = { dispatcher($0); return EmptyAwaitable.instance }
   }
 }

--- a/SwiftRedux/Middleware/Redux+Middleware.swift
+++ b/SwiftRedux/Middleware/Redux+Middleware.swift
@@ -15,12 +15,12 @@ public typealias ReduxMiddleware<State> = (MiddlewareInput<State>) -> DispatchMa
 /// Use this tracker to track middleware wrapping with an identifier (e.g. to
 /// ensure the ordering is correct).
 public struct DispatchWrapper {
-  let dispatch: AwaitableReduxDispatcher
+  let dispatcher: AwaitableReduxDispatcher
   let identifier: String
   
-  init(_ identifier: String, _ dispatch: @escaping AwaitableReduxDispatcher) {
+  init(_ identifier: String, _ dispatcher: @escaping AwaitableReduxDispatcher) {
     self.identifier = identifier
-    self.dispatch = dispatch
+    self.dispatcher = dispatcher
   }
 }
 
@@ -71,7 +71,7 @@ func combineMiddlewares<S>(_ middlewares: [ReduxMiddleware<S.State>])
       })
     
       let finalWrapper = combined(input)(rootWrapper)
-      lazyDispatcher.lateinitDispatcher = finalWrapper.dispatch
+      lazyDispatcher.lateinitDispatcher = finalWrapper.dispatcher
       return DispatchWrapper(finalWrapper.identifier, lazyDispatcher.dispatch)
     }
     
@@ -90,7 +90,7 @@ public func applyMiddlewares<Store>(
 {
   return {store in
     let wrapper = combineMiddlewares(middlewares)(store)
-    let enhanced = EnhancedStore(store, wrapper.dispatch)
+    let enhanced = EnhancedStore(store, wrapper.dispatcher)
     return DelegateStore(enhanced)
   }
 }

--- a/SwiftReduxTests/ReduxMiddlewareTest.swift
+++ b/SwiftReduxTests/ReduxMiddlewareTest.swift
@@ -35,7 +35,7 @@ public final class ReduxMiddlewareTest: XCTestCase {
       {input in
         {wrapper in DispatchWrapper("\(wrapper.identifier)-1", {
           data.append(1)
-          _ = wrapper.dispatch($0)
+          _ = wrapper.dispatcher($0)
           return EmptyAwaitable.instance
           
         })}
@@ -43,14 +43,14 @@ public final class ReduxMiddlewareTest: XCTestCase {
       {input in
         {wrapper in DispatchWrapper("\(wrapper.identifier)-2", {
           data.append(2)
-          _ = wrapper.dispatch($0)
+          _ = wrapper.dispatcher($0)
           return EmptyAwaitable.instance
         })}
       },
       {input in
         {wrapper in DispatchWrapper("\(wrapper.identifier)-3", {
           data.append(3)
-          _ = wrapper.dispatch($0)
+          _ = wrapper.dispatcher($0)
           return EmptyAwaitable.instance
         })}
       }
@@ -83,14 +83,14 @@ public final class ReduxMiddlewareTest: XCTestCase {
       {input in
         {wrapper in DispatchWrapper("\(wrapper.identifier)-1", {
           OSAtomicIncrement64(&dispatchCount)
-          _ = try! wrapper.dispatch($0).await()
+          _ = try! wrapper.dispatcher($0).await()
           return EmptyAwaitable.instance
         })}
       },
       {input in
         {wrapper in DispatchWrapper("\(wrapper.identifier)-2", {
           OSAtomicIncrement64(&dispatchCount)
-          _ = try! wrapper.dispatch($0).await()
+          _ = try! wrapper.dispatcher($0).await()
           return EmptyAwaitable.instance
         })}
       },
@@ -102,7 +102,7 @@ public final class ReduxMiddlewareTest: XCTestCase {
             _ = try! input.dispatcher($0).await()
           }
           
-          _ = try! wrapper.dispatch($0).await()
+          _ = try! wrapper.dispatcher($0).await()
           return EmptyAwaitable.instance
         })}
       }

--- a/SwiftReduxTests/ReduxRouterTest.swift
+++ b/SwiftReduxTests/ReduxRouterTest.swift
@@ -16,7 +16,7 @@ final class ReduxRouterTest: XCTestCase {
   
   override func setUp() {
     super.setUp()
-    let input = MiddlewareInput({()})
+    let input = MiddlewareInput(NoopDispatcher.instance, {()})
     
     let wrapper = DispatchWrapper("", {_ in
       self.dispatchCount += 1

--- a/SwiftReduxTests/ReduxRouterTest.swift
+++ b/SwiftReduxTests/ReduxRouterTest.swift
@@ -27,7 +27,7 @@ final class ReduxRouterTest: XCTestCase {
     self.dispatchCount = 0
 
     self.dispatch = RouterMiddleware(router: self.router)
-      .middleware(input)(wrapper).dispatch
+      .middleware(input)(wrapper).dispatcher
   }
 }
 

--- a/SwiftReduxTests/ReduxSagaTest.swift
+++ b/SwiftReduxTests/ReduxSagaTest.swift
@@ -50,7 +50,7 @@ public final class ReduxSagaTest: XCTestCase {
     
     self.dispatchCount = 0
     self.testEffect = TestEffect()
-    self.dispatch = SagaMiddleware(effects: [self.testEffect]).middleware(input)(wrapper).dispatch
+    self.dispatch = SagaMiddleware(effects: [self.testEffect]).middleware(input)(wrapper).dispatcher
   }
   
   public func test_sagaInputConvenienceConstructors_shouldWork() throws {
@@ -58,7 +58,7 @@ public final class ReduxSagaTest: XCTestCase {
     let input = SagaInput(SagaMonitor(), {()})
     
     /// When
-    let result = try input.dispatch(DefaultAction.noop).await()
+    let result = try input.dispatcher(DefaultAction.noop).await()
     
     /// Then
     XCTAssertTrue(result is ())

--- a/SwiftReduxTests/ReduxSagaTest.swift
+++ b/SwiftReduxTests/ReduxSagaTest.swift
@@ -41,7 +41,7 @@ public final class ReduxSagaTest: XCTestCase {
   
   override public func setUp() {
     super.setUp()
-    let input = MiddlewareInput({()})
+    let input = MiddlewareInput(NoopDispatcher.instance, {()})
     
     let wrapper = DispatchWrapper("") {_ in
       self.dispatchCount += 1


### PR DESCRIPTION
Add dispatcher to middleware input. This dispatcher has access to the final wrapped dispatcher, so using it to dispatch an action will propagate that action to all middlewares again. This is primarily used for `SagaEffects.put` to ensure actions dispatched in a Saga thread are caught by other Saga threads.