### PR TITLE
Saga middleware fix

### DIFF
--- a/SwiftRedux.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/SwiftRedux.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
-</dict>
+<dict/>
 </plist>

--- a/SwiftRedux/Core/Redux+RWLock.swift
+++ b/SwiftRedux/Core/Redux+RWLock.swift
@@ -20,8 +20,8 @@ public final class ReadWriteLock: ReadWriteLockType {
   
   #if DEBUG
   /// Use this initializer during testing to check state of the lock.
-  init(_ _lock: inout pthread_rwlock_t) {
-    self._mainLock = _lock
+  init(_ lock: inout pthread_rwlock_t) {
+    self._mainLock = lock
     pthread_rwlock_init(&self._mainLock, nil)
   }
   #endif

--- a/SwiftRedux/Middleware+Saga/Redux+Middleware+Saga.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Middleware+Saga.swift
@@ -10,38 +10,38 @@ import RxSwift
 
 /// Hook up sagas by subscribing for inner values and dispatching action for
 /// each saga output every time a new action arrives.
-public struct SagaMiddleware<State> {
+public final class SagaMiddleware<State> {
   private let monitor: SagaMonitorType
   private let effects: [SagaEffect<()>]
+  private let disposeBag: DisposeBag
   
-  public init<S>(monitor: SagaMonitorType, effects: S) where
-    S: Sequence, S.Element == SagaEffect<()>
-  {
+  init<S>(monitor: SagaMonitorType, effects: S) where S: Sequence, S.Element == SagaEffect<()> {
     self.monitor = monitor
     self.effects = effects.map({$0})
+    self.disposeBag = DisposeBag()
   }
   
-  public init<S>(effects: S) where S: Sequence, S.Element == SagaEffect<()> {
+  convenience public init<S>(effects: S) where S: Sequence, S.Element == SagaEffect<()> {
     self.init(monitor: SagaMonitor(), effects: effects)
   }
   
   public func middleware(_ input: MiddlewareInput<State>) -> DispatchMapper {
-    let monitor = self.monitor
-    let effects = self.effects
-    
     return {wrapper in
       let lastState = input.lastState
-      let sagaInput = SagaInput(monitor, lastState, input.dispatcher)
-      let sagaOutputs = effects.map({$0.invoke(sagaInput)})
+      let sagaInput = SagaInput(self.monitor, lastState, input.dispatcher)
+      let sagaOutputs = self.effects.map({$0.invoke(sagaInput)})
       let newWrapperId = "\(wrapper.identifier)-saga"
-      sagaOutputs.forEach({$0.subscribeByDefault({_ in})})
       
-      return DispatchWrapper(newWrapperId) {action in
+      /// We declare the wrapper first then subscribe to capture the saga
+      /// outputs and prevent their subscriptions from being disposed of.
+      let newWrapper = DispatchWrapper(newWrapperId) {action in
         let dispatchResult = try! wrapper.dispatcher(action).await()
-        _ = try! monitor.dispatch(action).await()
-        sagaOutputs.forEach({_ = $0.onAction(action)})
+        _ = try! self.monitor.dispatch(action).await()
         return JustAwaitable(dispatchResult)
       }
+      
+      sagaOutputs.forEach({$0.subscribe({_ in}).disposed(by: self.disposeBag)})
+      return newWrapper
     }
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Effects.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Effects.swift
@@ -82,8 +82,9 @@ public final class SagaEffects {
   
   /// Create an empty effect.
   ///
+  /// - Parameter type: The type of emission.
   /// - Returns: An Effect instance.
-  public static func empty<R>() -> EmptyEffect<R> {
+  public static func empty<R>(forType type: R.Type) -> EmptyEffect<R> {
     return EmptyEffect()
   }
   

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Output.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Output.swift
@@ -15,7 +15,6 @@ public final class SagaOutput<T>: Awaitable<T> {
   let monitor: SagaMonitorType
   let onAction: AwaitableReduxDispatcher
   let source: Observable<T>
-  private let disposeBag: DisposeBag
   
   /// Create a Saga output instance. We need to register this output with a
   /// Saga monitor to trigger action dispatcher when one arrives.
@@ -29,7 +28,6 @@ public final class SagaOutput<T>: Awaitable<T> {
        _ onAction: @escaping AwaitableReduxDispatcher = NoopDispatcher.instance) {
     self.monitor = monitor
     self.onAction = onAction
-    disposeBag = DisposeBag()
     let uniqueID = DefaultUniqueIDProvider.next()
     
     self.source = source.do(
@@ -69,10 +67,6 @@ public final class SagaOutput<T>: Awaitable<T> {
   
   func subscribe(_ callback: @escaping (T) -> Void) -> Disposable {
     return self.source.subscribe(onNext: callback)
-  }
-  
-  func subscribeByDefault(_ callback: @escaping (T) -> Void) {
-    self.subscribe(callback).disposed(by: self.disposeBag)
   }
   
   override public func await() throws -> T {

--- a/SwiftReduxTests/ReduxLockTest.swift
+++ b/SwiftReduxTests/ReduxLockTest.swift
@@ -13,8 +13,8 @@ final class ReduxLockTest: XCTestCase {
   #if DEBUG
   func test_readWriteLock_shouldDestroyLockOnDeinit() {
     /// Setup
-    var _lock = pthread_rwlock_t()
-    var disposableLock: ReadWriteLock? = .init(&_lock)
+    var lock = pthread_rwlock_t()
+    var disposableLock: ReadWriteLock? = .init(&lock)
     let dispatchGroup = DispatchGroup()
     dispatchGroup.enter()
     
@@ -32,7 +32,7 @@ final class ReduxLockTest: XCTestCase {
     dispatchGroup.wait()
     
     /// Then
-    XCTAssertNotEqual(pthread_rwlock_destroy(&_lock), 0)
+    XCTAssertNotEqual(pthread_rwlock_destroy(&lock), 0)
   }
   #endif
   

--- a/SwiftReduxTests/ReduxSagaTest+Effect.swift
+++ b/SwiftReduxTests/ReduxSagaTest+Effect.swift
@@ -113,7 +113,7 @@ public final class ReduxSagaEffectTest: XCTestCase {
     let dispatch: ReduxDispatcher = {_ in dispatchCount += 1}
     let monitor = SagaMonitor()
     let input = SagaInput(monitor, {()}, dispatch)
-    let effect: SagaEffect<Int> = SagaEffects.empty()
+    let effect = SagaEffects.empty(forType: Int.self)
     let output = effect.invoke(input)
     
     /// When


### PR DESCRIPTION
Fix issue with Saga output subscriptions not being retained by strongly capturing saga outputs in the wrapped dispatch block. All `SagaOutput.onAction` instances are now invoked via the saga monitor.