### PR TITLE
Saga scheduler and cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ xcode_workspace: SwiftRedux.xcworkspace
 xcode_scheme: SwiftRedux
 xcode_sdk: iphonesimulator12.1
 before_install:
-  - gem install cocoapods --pre
-  - gem install slather --pre
+  - gem install cocoapods
+  - gem install slather
   - gem install xcpretty
   - pod install
 

--- a/SwiftRedux/Middleware+Saga/Redux+Middleware+Saga.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Middleware+Saga.swift
@@ -15,7 +15,8 @@ public final class SagaMiddleware<State> {
   private var _middleware: ReduxMiddleware<State>!
   private let disposeBag: DisposeBag
   
-  init(scheduler: SchedulerType, effects: [SagaEffect<()>]) {
+  init(scheduler: SchedulerType = SerialDispatchQueueScheduler(qos: .background),
+       effects: [SagaEffect<()>]) {
     self.disposeBag = DisposeBag()
     
     self._middleware = {input in
@@ -39,11 +40,6 @@ public final class SagaMiddleware<State> {
         return newWrapper
       }
     }
-  }
-  
-  convenience public init(effects: [SagaEffect<()>]) {
-    let scheduler = SerialDispatchQueueScheduler(qos: .background)
-    self.init(scheduler: scheduler, effects: effects)
   }
 }
 

--- a/SwiftRedux/Middleware+Saga/Redux+Middleware+Saga.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Middleware+Saga.swift
@@ -15,8 +15,8 @@ public final class SagaMiddleware<State> {
   private var _middleware: ReduxMiddleware<State>!
   private let disposeBag: DisposeBag
   
-  init(scheduler: SchedulerType = SerialDispatchQueueScheduler(qos: .background),
-       effects: [SagaEffect<()>]) {
+  public init(scheduler: SchedulerType = SerialDispatchQueueScheduler(qos: .background),
+              effects: [SagaEffect<()>]) {
     self.disposeBag = DisposeBag()
     
     self._middleware = {input in

--- a/SwiftRedux/Middleware+Saga/Redux+Middleware+Saga.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Middleware+Saga.swift
@@ -9,39 +9,49 @@
 import RxSwift
 
 /// Hook up sagas by subscribing for inner values and dispatching action for
-/// each saga output every time a new action arrives.
+/// each saga output every time a new action arrives. We can also specify a
+/// scheduler to perform asynchronous work on.
 public final class SagaMiddleware<State> {
-  private let monitor: SagaMonitorType
-  private let effects: [SagaEffect<()>]
+  public private(set) var middleware: ReduxMiddleware<State>
   private let disposeBag: DisposeBag
   
-  init<S>(monitor: SagaMonitorType, effects: S) where S: Sequence, S.Element == SagaEffect<()> {
-    self.monitor = monitor
-    self.effects = effects.map({$0})
+  init(monitor: SagaMonitorType, scheduler: SchedulerType, effects: [SagaEffect<()>]) {
     self.disposeBag = DisposeBag()
-  }
-  
-  convenience public init<S>(effects: S) where S: Sequence, S.Element == SagaEffect<()> {
-    self.init(monitor: SagaMonitor(), effects: effects)
-  }
-  
-  public func middleware(_ input: MiddlewareInput<State>) -> DispatchMapper {
-    return {wrapper in
-      let lastState = input.lastState
-      let sagaInput = SagaInput(self.monitor, lastState, input.dispatcher)
-      let sagaOutputs = self.effects.map({$0.invoke(sagaInput)})
-      let newWrapperId = "\(wrapper.identifier)-saga"
-      
-      /// We declare the wrapper first then subscribe to capture the saga
-      /// outputs and prevent their subscriptions from being disposed of.
-      let newWrapper = DispatchWrapper(newWrapperId) {action in
-        let dispatchResult = try! wrapper.dispatcher(action).await()
-        _ = try! self.monitor.dispatch(action).await()
-        return JustAwaitable(dispatchResult)
+    self.middleware = {_ in {$0}}
+    
+    self.middleware = {input in
+      return {wrapper in
+        let sagaInput = SagaInput(dispatcher: input.dispatcher,
+                                  lastState: input.lastState,
+                                  monitor: monitor,
+                                  scheduler: scheduler)
+        
+        let sagaOutputs = effects.map({$0.invoke(sagaInput)})
+        let newWrapperId = "\(wrapper.identifier)-saga"
+        
+        /// We declare the wrapper first then subscribe to capture the saga
+        /// outputs and prevent their subscriptions from being disposed of.
+        let newWrapper = DispatchWrapper(newWrapperId) {action in
+          let dispatchResult = try! wrapper.dispatcher(action).await()
+          _ = try! monitor.dispatch(action).await()
+          return JustAwaitable(dispatchResult)
+        }
+        
+        sagaOutputs.forEach({$0.subscribe({_ in}).disposed(by: self.disposeBag)})
+        return newWrapper
       }
-      
-      sagaOutputs.forEach({$0.subscribe({_ in}).disposed(by: self.disposeBag)})
-      return newWrapper
     }
   }
+  
+  convenience public init(scheduler: SchedulerType, effects: [SagaEffect<()>]) {
+    self.init(monitor: SagaMonitor(), scheduler: scheduler, effects: effects)
+  }
+  
+  convenience public init(effects: [SagaEffect<()>]) {
+    let scheduler = SerialDispatchQueueScheduler(qos: .background)
+    self.init(scheduler: scheduler, effects: effects)
+  }
 }
+
+// MARK: - MiddlewareProviderType
+extension SagaMiddleware: MiddlewareProviderType {}

--- a/SwiftRedux/Middleware+Saga/Redux+Middleware+Saga.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Middleware+Saga.swift
@@ -12,14 +12,13 @@ import RxSwift
 /// each saga output every time a new action arrives. We can also specify a
 /// scheduler to perform asynchronous work on.
 public final class SagaMiddleware<State> {
-  public private(set) var middleware: ReduxMiddleware<State>
+  private var _middleware: ReduxMiddleware<State>!
   private let disposeBag: DisposeBag
   
   init(scheduler: SchedulerType, effects: [SagaEffect<()>]) {
     self.disposeBag = DisposeBag()
-    self.middleware = {_ in {$0}}
     
-    self.middleware = {input in
+    self._middleware = {input in
       return {wrapper in
         let sagaInput = SagaInput(dispatcher: input.dispatcher,
                                   lastState: input.lastState,
@@ -49,4 +48,8 @@ public final class SagaMiddleware<State> {
 }
 
 // MARK: - MiddlewareProviderType
-extension SagaMiddleware: MiddlewareProviderType {}
+extension SagaMiddleware: MiddlewareProviderType {
+  public var middleware: ReduxMiddleware<State> {
+    return self._middleware!
+  }
+}

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Create.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Create.swift
@@ -9,22 +9,6 @@
 import RxSwift
 import SwiftFP
 
-/// Effect whose output simply emits some specified element.
-final class JustEffect<R>: SagaEffect<R> {
-  private let value: R
-  
-  init(_ value: R) {
-    self.value = value
-  }
-  
-  override func invoke(_ input: SagaInput) -> SagaOutput<R> {
-    return SagaOutput(input.monitor, .just(self.value))
-  }
-}
-
-// MARK: - SingleSagaEffectType
-extension JustEffect: SingleSagaEffectType {}
-
 /// Effect whose output simply accepts an Observable. The resulting emissions
 /// are also wrapped in Try to prevent stream from erroring out.
 public final class FromEffect<O>: SagaEffect<Try<O.E>> where O: ObservableConvertibleType {

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Debounce.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Debounce.swift
@@ -13,17 +13,15 @@ import Foundation
 final class DebounceEffect<R>: SagaEffect<R> {
   private let source: SagaEffect<R>
   private let debounce: TimeInterval
-  private let scheduler: SchedulerType
   
-  init(_ source: SagaEffect<R>, _ debounce: TimeInterval, _ scheduler: SchedulerType) {
+  init(_ source: SagaEffect<R>, _ debounce: TimeInterval) {
     self.source = source
     self.debounce = debounce
-    self.scheduler = scheduler
   }
   
   override func invoke(_ input: SagaInput) -> SagaOutput<R> {
     return self.source.invoke(input)
-      .debounce(bySeconds: self.debounce, usingScheduler: self.scheduler)
+      .debounce(bySeconds: self.debounce, usingScheduler: input.scheduler)
   }
 }
 
@@ -31,15 +29,9 @@ extension SagaEffectConvertibleType {
 
   /// Invoke a debounce effect on the current effect.
   ///
-  /// - Parameters:
-  ///   - seconds: The debounce interval in seconds.
-  ///   - scheduler: THe scheduler to debounce by.
+  /// - Parameter seconds: The debounce interval in seconds.
   /// - Returns: A SagaEffect instance.
-  public func debounce(
-    bySeconds seconds: TimeInterval,
-    usingScheduler scheduler: SchedulerType = SerialDispatchQueueScheduler(qos: .default))
-    -> SagaEffect<R>
-  {
-    return self.transform(with: {DebounceEffect($0, seconds, scheduler)})
+  public func debounce(bySeconds seconds: TimeInterval) -> SagaEffect<R> {
+    return self.transform(with: {DebounceEffect($0, seconds)})
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Delay.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Delay.swift
@@ -12,20 +12,14 @@ import RxSwift
 /// block.
 public final class DelayEffect: SagaEffect<()> {
   private let delay: TimeInterval
-  private let scheduler: SchedulerType
   
-  init(_ delay: TimeInterval, _ scheduler: SchedulerType) {
+  init(_ delay: TimeInterval) {
     self.delay = delay
-    self.scheduler = scheduler
-  }
-  
-  convenience init(_ delay: TimeInterval) {
-    self.init(delay, SerialDispatchQueueScheduler(qos: .default))
   }
   
   override public func invoke(_ input: SagaInput) -> SagaOutput<R> {
     return SagaOutput(input.monitor, Observable<Int>
-      .timer(self.delay, scheduler: self.scheduler)
+      .timer(self.delay, scheduler: input.scheduler)
       .map({_ in ()}))
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Effects.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Effects.swift
@@ -64,14 +64,10 @@ public final class SagaEffects {
   
   /// Create a select effect.
   ///
-  /// - Parameters:
-  ///   - type: The type of State to be selected from.
-  ///   - selector: Selector function.
+  /// - Parameter type: The type of State to be selected from.
   /// - Returns: An Effect instance.
-  public static func select<State, R>(fromType type: State.Type, _ fn: @escaping (State) -> R)
-    -> SelectEffect<State, R>
-  {
-    return SelectEffect(fn)
+  public static func select<State>(type: State.Type) -> SelectEffect<State> {
+    return SelectEffect()
   }
   
   /// Create a TakeActionEffect.

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Effects.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Effects.swift
@@ -14,48 +14,6 @@ import SwiftFP
 public final class SagaEffects {
   init() {}
   
-  /// Create a just effect.
-  ///
-  /// - Parameter value: The value to form the effect with.
-  /// - Returns: An Effect instance.
-  static func just<R>(_ value: R) -> JustEffect<R> {
-    return JustEffect(value)
-  }
-  
-  /// Create a put effect.
-  ///
-  /// - Parameters:
-  ///   - param: The parameter to put into Redux state.
-  ///   - actionCreator: The action creator function.
-  ///   - queue: The queue on which to dispatch the action.
-  /// - Returns: An Effect instance.
-  static func put<R>(
-    _ param: SagaEffect<R>,
-    actionCreator: @escaping (R) -> ReduxActionType,
-    usingQueue queue: DispatchQueue = .global(qos: .default))
-    -> PutEffect<R>
-  {
-    return PutEffect(param, actionCreator, queue)
-  }
-  
-  /// Convenience function to create a put effect with a raw value.
-  ///
-  /// - Parameters:
-  ///   - param: The parameter to put into Redux state.
-  ///   - actionCreator: The action creator function.
-  ///   - queue: The queue on which to dispatch the action.
-  /// - Returns: An Effect instance.
-  static func put<R>(
-    _ param: R,
-    actionCreator: @escaping (R) -> ReduxActionType,
-    usingQueue queue: DispatchQueue = .global(qos: .default))
-    -> PutEffect<R>
-  {
-    return self.put(SagaEffects.just(param),
-                    actionCreator: actionCreator,
-                    usingQueue: queue)
-  }
-  
   /// Create an await effect with a creator function.
   ///
   /// - Parameter creator: Function that await for results from multiple effects.
@@ -98,16 +56,10 @@ public final class SagaEffects {
   
   /// Convenience function to create a put effect that simply puts some action.
   ///
-  /// - Parameters:
-  ///   - action: The action to be dispatched.
-  ///   - queue: The queue on which to dispatch the action.
+  /// - Parameter action: The action to be dispatched.
   /// - Returns: An Effect instance.
-  public static func put(
-    _ action: ReduxActionType,
-    usingQueue queue: DispatchQueue = .global(qos: .default))
-    -> PutEffect<()>
-  {
-    return SagaEffects.put((), actionCreator: {action})
+  public static func put(_ action: ReduxActionType) -> PutEffect<()> {
+    return PutEffect(action)
   }
   
   /// Create a select effect.

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Output.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Output.swift
@@ -43,10 +43,6 @@ public final class SagaOutput<T>: Awaitable<T> {
     return SagaOutput<R>(self.monitor, source)
   }
   
-  func map<R>(_ fn: @escaping (T) throws -> R) -> SagaOutput<R> {
-    return self.with(source: self.source.map(fn))
-  }
-  
   func flatMap<R>(_ fn: @escaping (T) throws -> SagaOutput<R>) -> SagaOutput<R> {
     return self.with(source: self.source.map(fn).flatMap({$0.source}))
   }
@@ -57,12 +53,7 @@ public final class SagaOutput<T>: Awaitable<T> {
   
   func debounce(bySeconds sec: TimeInterval,
                 usingScheduler scheduler: SchedulerType) -> SagaOutput<T> {
-    guard sec > 0 else { return self }
     return self.with(source: self.source.debounce(sec, scheduler: scheduler))
-  }
-  
-  func observeOn(_ scheduler: SchedulerType) -> SagaOutput<T> {
-    return self.with(source: self.source.observeOn(scheduler))
   }
   
   func subscribe(_ callback: @escaping (T) -> Void) -> Disposable {

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Select.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Select.swift
@@ -6,20 +6,26 @@
 //  Copyright © 2018 Hai Pham. All rights reserved.
 //
 
+import RxSwift
+
 /// Effect whose output selects some value from a Redux store's managed state.
 /// The extracted value can then be fed to other effects.
 public final class SelectEffect<State, R>: SagaEffect<R> {
-  private let _selector: (State) -> R
+  private let selector: (State) -> R
   
   init(_ selector: @escaping (State) -> R) {
-    self._selector = selector
+    self.selector = selector
   }
   
   override public func invoke(_ input: SagaInput) -> SagaOutput<R> {
-    let lastState = input.lastState()
-    precondition(lastState is State)
-    let emission = self._selector(lastState as! State)
-    return SagaOutput(input.monitor, .just(emission))
+    let single = Single.create(subscribe: {(obs: (SingleEvent<R>) -> Void) -> Disposable in
+      let lastState = input.lastState()
+      precondition(lastState is State)
+      obs(.success(self.selector(lastState as! State)))
+      return Disposables.create()
+    })
+    
+    return SagaOutput(input.monitor, single.asObservable())
   }
   
   /// Await for the first result that arrives. Since this can never throw an

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Select.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Select.swift
@@ -10,18 +10,14 @@ import RxSwift
 
 /// Effect whose output selects some value from a Redux store's managed state.
 /// The extracted value can then be fed to other effects.
-public final class SelectEffect<State, R>: SagaEffect<R> {
-  private let selector: (State) -> R
+public final class SelectEffect<State>: SagaEffect<State> {
+  override init() {}
   
-  init(_ selector: @escaping (State) -> R) {
-    self.selector = selector
-  }
-  
-  override public func invoke(_ input: SagaInput) -> SagaOutput<R> {
+  override public func invoke(_ input: SagaInput) -> SagaOutput<State> {
     let single = Single.create(subscribe: {(obs: (SingleEvent<R>) -> Void) -> Disposable in
       let lastState = input.lastState()
       precondition(lastState is State)
-      obs(.success(self.selector(lastState as! State)))
+      obs(.success(lastState as! State))
       return Disposables.create()
     })
     

--- a/SwiftRedux/Middleware+Saga/Redux+Saga+Take.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga+Take.swift
@@ -20,7 +20,7 @@ public class TakeActionEffect<Action, P>: SagaEffect<P> where Action: ReduxActio
   override public func invoke(_ input: SagaInput) -> SagaOutput<R> {
     let paramStream = PublishSubject<P>()
     
-    return SagaOutput(input.monitor, paramStream) {
+    return SagaOutput(input.monitor, paramStream.observeOn(input.scheduler)) {
       ($0 as? Action).flatMap(self._paramExtractor).map(paramStream.onNext)
       return EmptyAwaitable.instance
     }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import RxSwift
 
 /// Errors specific to Redux Saga.
 public enum SagaError: LocalizedError {
@@ -34,23 +35,28 @@ public enum SagaError: LocalizedError {
 
 /// Input for each saga effect.
 public struct SagaInput {
-  let monitor: SagaMonitorType
-  let lastState: ReduxStateGetter<Any>
   let dispatcher: AwaitableReduxDispatcher
+  let lastState: ReduxStateGetter<Any>
+  let monitor: SagaMonitorType
+  let scheduler: SchedulerType
   
-  init(_ monitor: SagaMonitorType,
-       _ lastState: @escaping ReduxStateGetter<Any>,
-       _ dispatcher: @escaping AwaitableReduxDispatcher) {
-    self.monitor = monitor
-    self.lastState = lastState
+  public init(dispatcher: @escaping AwaitableReduxDispatcher,
+              lastState: @escaping ReduxStateGetter<Any>,
+              monitor: SagaMonitorType,
+              scheduler: SchedulerType = SerialDispatchQueueScheduler(qos: .background)) {
     self.dispatcher = dispatcher
+    self.lastState = lastState
+    self.monitor = monitor
+    self.scheduler = scheduler
   }
   
-  init(_ monitor: SagaMonitorType,
-       _ lastState: @escaping ReduxStateGetter<Any>,
-       _ dispatcher: @escaping ReduxDispatcher = {_ in}) {
-    self.monitor = monitor
-    self.lastState = lastState
+  public init(dispatcher: @escaping ReduxDispatcher = {_ in},
+              lastState: @escaping ReduxStateGetter<Any>,
+              monitor: SagaMonitorType,
+              scheduler: SchedulerType = SerialDispatchQueueScheduler(qos: .background)) {
     self.dispatcher = { dispatcher($0); return EmptyAwaitable.instance }
+    self.lastState = lastState
+    self.monitor = monitor
+    self.scheduler = scheduler
   }
 }

--- a/SwiftRedux/Middleware+Saga/Redux+Saga.swift
+++ b/SwiftRedux/Middleware+Saga/Redux+Saga.swift
@@ -35,28 +35,26 @@ public enum SagaError: LocalizedError {
 
 /// Input for each saga effect.
 public struct SagaInput {
+  public let monitor: SagaMonitor
   let dispatcher: AwaitableReduxDispatcher
   let lastState: ReduxStateGetter<Any>
-  let monitor: SagaMonitorType
   let scheduler: SchedulerType
   
   public init(dispatcher: @escaping AwaitableReduxDispatcher,
               lastState: @escaping ReduxStateGetter<Any>,
-              monitor: SagaMonitorType,
               scheduler: SchedulerType = SerialDispatchQueueScheduler(qos: .background)) {
+    self.monitor = SagaMonitor()
     self.dispatcher = dispatcher
     self.lastState = lastState
-    self.monitor = monitor
     self.scheduler = scheduler
   }
   
   public init(dispatcher: @escaping ReduxDispatcher = {_ in},
               lastState: @escaping ReduxStateGetter<Any>,
-              monitor: SagaMonitorType,
               scheduler: SchedulerType = SerialDispatchQueueScheduler(qos: .background)) {
+    self.monitor = SagaMonitor()
     self.dispatcher = { dispatcher($0); return EmptyAwaitable.instance }
     self.lastState = lastState
-    self.monitor = monitor
     self.scheduler = scheduler
   }
 }

--- a/SwiftRedux/Middleware/Redux+Middleware.swift
+++ b/SwiftRedux/Middleware/Redux+Middleware.swift
@@ -48,16 +48,19 @@ final class LazyDispatcher {
     didSet { self.lateinitDispatcher.map(self.didSetDispatcher) }
   }
   
-  private(set) var dispatch: AwaitableReduxDispatcher
+  var dispatch: AwaitableReduxDispatcher {
+    return self._dispatch!
+  }
+  
   private var buffer: [ReduxActionType]
   private let semaphore: DispatchSemaphore
+  private var _dispatch: AwaitableReduxDispatcher!
   
   init() {
-    self.dispatch = {_ in EmptyAwaitable.instance}
     self.buffer = []
     self.semaphore = DispatchSemaphore(value: 1)
     
-    self.dispatch = {
+    self._dispatch = {
       self.semaphore.wait()
       defer { self.semaphore.signal() }
       

--- a/SwiftRedux/Middleware/Redux+Middleware.swift
+++ b/SwiftRedux/Middleware/Redux+Middleware.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import RxSwift
 
 /// Function that maps one dispatch to another.
 public typealias DispatchMapper = (DispatchWrapper) -> DispatchWrapper

--- a/SwiftReduxTests/ReduxSagaTest+Effect.swift
+++ b/SwiftReduxTests/ReduxSagaTest+Effect.swift
@@ -37,9 +37,7 @@ public final class ReduxSagaEffectTest: XCTestCase {
     var dispatched = [ReduxActionType]()
     
     /// When
-    let input = SagaInput(dispatcher: {dispatched.append($0)},
-                          lastState: {4},
-                          monitor: SagaMonitor())
+    let input = SagaInput(dispatcher: {dispatched.append($0)}, lastState: {4})
     
     let result = try SagaEffects.await {input -> Int in
       SagaEffects.put(0, actionCreator: Action.init).await(input)
@@ -59,15 +57,13 @@ public final class ReduxSagaEffectTest: XCTestCase {
     /// Setup
     var dispatchCount = 0
     let dispatch: ReduxDispatcher = {_ in dispatchCount += 1}
-    
     let effect = SagaEffect<Int>()
-    let monitor = SagaMonitor()
-    let input = SagaInput(dispatcher: dispatch, lastState: {()}, monitor: monitor)
+    let input = SagaInput(dispatcher: dispatch, lastState: {()})
     let output = effect.invoke(input)
     
     /// When
     _ = dispatch(DefaultAction.noop)
-    _ = monitor.dispatch(DefaultAction.noop)
+    _ = input.monitor.dispatch(DefaultAction.noop)
     
     /// Then
     XCTAssertEqual(dispatchCount, 1)
@@ -81,7 +77,7 @@ public final class ReduxSagaEffectTest: XCTestCase {
   public func test_justCallEffect_shouldReturnCorrectResult() throws {
     /// Setup
     let source = Single.just(1)
-    let input = SagaInput(lastState: {()}, monitor: SagaMonitor())
+    let input = SagaInput(lastState: {()})
     
     /// When
     let result = try SagaEffects.call(source).await(input)
@@ -104,11 +100,7 @@ public final class ReduxSagaEffectTest: XCTestCase {
     
     /// When
     var dispatched = [ReduxActionType]()
-
-    let input = SagaInput(dispatcher: {dispatched.append($0)},
-                          lastState: {()},
-                          monitor: SagaMonitor())
-    
+    let input = SagaInput(dispatcher: {dispatched.append($0)}, lastState: {()})
     try? effect.await(input)
     
     /// Then
@@ -120,14 +112,13 @@ public final class ReduxSagaEffectTest: XCTestCase {
     /// Setup
     var dispatchCount = 0
     let dispatch: ReduxDispatcher = {_ in dispatchCount += 1}
-    let monitor = SagaMonitor()
-    let input = SagaInput(dispatcher: dispatch, lastState: {()}, monitor: monitor)
+    let input = SagaInput(dispatcher: dispatch, lastState: {()})
     let effect = SagaEffects.empty(forType: Int.self)
     let output = effect.invoke(input)
     
     /// When
     _ = dispatch(DefaultAction.noop)
-    _ = monitor.dispatch(DefaultAction.noop)
+    _ = input.monitor.dispatch(DefaultAction.noop)
     
     /// Then
     XCTAssertEqual(dispatchCount, 1)
@@ -148,11 +139,7 @@ public final class ReduxSagaEffectTest: XCTestCase {
       })
     
     let effect = SagaEffects.from(source)
-
-    let input = SagaInput(dispatcher: NoopDispatcher.instance,
-                          lastState: {()},
-                          monitor: SagaMonitor())
-    
+    let input = SagaInput(dispatcher: NoopDispatcher.instance, lastState: {()})
     effect.invoke(input).source.subscribe(observer).disposed(by: self.disposeBag)
     
     /// When
@@ -168,14 +155,13 @@ public final class ReduxSagaEffectTest: XCTestCase {
     /// Setup
     var dispatchCount = 0
     let dispatch: ReduxDispatcher = {_ in dispatchCount += 1}
-    let monitor = SagaMonitor()
-    let input = SagaInput(dispatcher: dispatch, lastState: {()}, monitor: monitor)
+    let input = SagaInput(dispatcher: dispatch, lastState: {()})
     let effect = SagaEffects.just(10)
     let output = effect.invoke(input)
     
     /// When
     _ = dispatch(DefaultAction.noop)
-    _ = monitor.dispatch(DefaultAction.noop)
+    _ = input.monitor.dispatch(DefaultAction.noop)
     let value1 = try output.await(timeoutMillis: self.timeout)
     let value2 = try output.await(timeoutMillis: self.timeout)
     let value3 = try output.await(timeoutMillis: self.timeout)
@@ -199,16 +185,15 @@ public final class ReduxSagaEffectTest: XCTestCase {
     }
     
     let queue = DispatchQueue.global(qos: .background)
-    let monitor = SagaMonitor()
-    let input = SagaInput(dispatcher: dispatch, lastState: {()}, monitor: monitor)
+    let input = SagaInput(dispatcher: dispatch, lastState: {()})
     let effect1 = SagaEffects.put(Action.input(200), usingQueue: queue)
     let effect2 = SagaEffects.put(200, actionCreator: Action.input, usingQueue: queue)
     let output1 = effect1.invoke(input)
     let output2 = effect2.invoke(input)
     
     /// When
-    _ = monitor.dispatch(DefaultAction.noop)
-    _ = monitor.dispatch(DefaultAction.noop)
+    _ = input.monitor.dispatch(DefaultAction.noop)
+    _ = input.monitor.dispatch(DefaultAction.noop)
     _ = try output1.await(timeoutMillis: self.timeout)
     _ = try output2.await(timeoutMillis: self.timeout)
     waitForExpectations(timeout: self.timeout, handler: nil)
@@ -236,11 +221,7 @@ public final class ReduxSagaEffectTest: XCTestCase {
     }
     
     var dispatched = [ReduxActionType]()
-    
-    let input = SagaInput(dispatcher: { dispatched.append($0) },
-                          lastState: {()},
-                          monitor: SagaMonitor())
-    
+    let input = SagaInput(dispatcher: { dispatched.append($0) }, lastState: {()})
     let actions = (0..<100).map(Action.init)
     
     /// Setup
@@ -255,14 +236,13 @@ public final class ReduxSagaEffectTest: XCTestCase {
     /// Setup
     var dispatchCount = 0
     let dispatch: ReduxDispatcher = {_ in dispatchCount += 1}
-    let monitor = SagaMonitor()
-    let input = SagaInput(dispatcher: dispatch, lastState: {()}, monitor: monitor)
+    let input = SagaInput(dispatcher: dispatch, lastState: {()})
     let effect = SagaEffects.select(fromType: State.self, {_ in 100})
     let output = effect.invoke(input)
     
     /// When
     _ = dispatch(DefaultAction.noop)
-    _ = monitor.dispatch(DefaultAction.noop)
+    _ = input.monitor.dispatch(DefaultAction.noop)
     let value1 = try output.await(timeoutMillis: self.timeout)
     let value2 = try output.await(timeoutMillis: self.timeout)
     let value3 = try output.await(timeoutMillis: self.timeout)

--- a/SwiftReduxTests/ReduxSagaTest+Effect.swift
+++ b/SwiftReduxTests/ReduxSagaTest+Effect.swift
@@ -13,8 +13,6 @@ import XCTest
 @testable import SwiftRedux
 
 public final class ReduxSagaEffectTest: XCTestCase {
-  public typealias State = ()
-  
   private let timeout: Double = 10_000
   private var disposeBag: DisposeBag!
   
@@ -44,7 +42,7 @@ public final class ReduxSagaEffectTest: XCTestCase {
       SagaEffects.put(Action(1)).await(input)
       SagaEffects.put(Action(2)).await(input)
       SagaEffects.put(Action(3)).await(input)
-      return SagaEffects.select(fromType: Int.self, {$0}).await(input)
+      return SagaEffects.select(type: Int.self).await(input)
       }.await(input)
     
     /// Then
@@ -169,12 +167,12 @@ public final class ReduxSagaEffectTest: XCTestCase {
     XCTAssertEqual(expectedActions, actions)
   }
   
-  public func test_selectEffect_shouldEmitOnlySelectedStateValue() throws {
+  public func test_selectEffect_shouldEmitStateValue() throws {
     /// Setup
     var dispatchCount = 0
     let dispatch: ReduxDispatcher = {_ in dispatchCount += 1}
-    let input = SagaInput(dispatcher: dispatch, lastState: {()})
-    let effect = SagaEffects.select(fromType: State.self, {_ in 100})
+    let input = SagaInput(dispatcher: dispatch, lastState: {100})
+    let effect = SagaEffects.select(type: Int.self)
     let output = effect.invoke(input)
     
     /// When

--- a/SwiftReduxTests/ReduxSagaTest+TakeEffect.swift
+++ b/SwiftReduxTests/ReduxSagaTest+TakeEffect.swift
@@ -38,7 +38,7 @@ public final class ReduxSagaTakeEffectTest: XCTestCase {
     var dispatchCount = 0
     let dispatch: ReduxDispatcher = {_ in dispatchCount += 1}
     let monitor = SagaMonitor()
-    let input = SagaInput(monitor, {()}, dispatch)
+    let input = SagaInput(dispatcher: dispatch, lastState: {()}, monitor: monitor)
     
     let callEffectCreator: (Int) -> SagaEffect<Int> = {
       let scheduler = ConcurrentDispatchQueueScheduler(qos: .background)
@@ -94,7 +94,7 @@ public final class ReduxSagaTakeEffectTest: XCTestCase {
     let effect = SagaEffects.takeAction(type: TakeAction.self, {_ in 1}).debounce(bySeconds: 2)
     
     let monitor = SagaMonitor()
-    let input = SagaInput(monitor, {()})
+    let input = SagaInput(lastState: {()}, monitor: monitor)
     let output = effect.invoke(input)
     var values = [Int]()
     

--- a/SwiftReduxTests/ReduxSagaTest.swift
+++ b/SwiftReduxTests/ReduxSagaTest.swift
@@ -13,7 +13,7 @@ import XCTest
 public final class ReduxSagaTest: XCTestCase {
   public func test_sagaInputConvenienceConstructors_shouldWork() throws {
     /// Setup
-    let input = SagaInput(SagaMonitor(), {()})
+    let input = SagaInput(lastState: {()}, monitor: SagaMonitor())
     
     /// When
     let result = try input.dispatcher(DefaultAction.noop).await()

--- a/SwiftReduxTests/ReduxSagaTest.swift
+++ b/SwiftReduxTests/ReduxSagaTest.swift
@@ -13,7 +13,7 @@ import XCTest
 public final class ReduxSagaTest: XCTestCase {
   public func test_sagaInputConvenienceConstructors_shouldWork() throws {
     /// Setup
-    let input = SagaInput(lastState: {()}, monitor: SagaMonitor())
+    let input = SagaInput(lastState: {()})
     
     /// When
     let result = try input.dispatcher(DefaultAction.noop).await()

--- a/SwiftReduxTests/ReduxSagaTest.swift
+++ b/SwiftReduxTests/ReduxSagaTest.swift
@@ -62,7 +62,7 @@ public final class ReduxSagaTest: XCTestCase {
       })
     
     let store = applyMiddlewares([
-      SagaMiddleware(effects: [effect]).middleware
+      SagaMiddleware(scheduler: MainScheduler.instance, effects: [effect]).middleware
       ])(SimpleStore.create((), {(_, _) in ()}))
     
     /// When


### PR DESCRIPTION
- Add scheduler to `SagaMiddleware` and `SagaInput` so that saga effects can use it instead of defining their own.
- Automatically initialize `SagaMonitor` in `SagaInput`.
- Remove obsolete `SagaEffects.put` variants and `JustEffect`.
- Remove state selector from `SelectEffect`.