### PR TITLE
AllEffect

### DIFF
--- a/CompleteRedux.xcodeproj/project.pbxproj
+++ b/CompleteRedux.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		D381794921AD015D007B33A6 /* CompleteRedux.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D3943ECE1FA32D5600898233 /* CompleteRedux.framework */; };
 		D38E12B92257AE3600A84040 /* Redux+Saga+Await.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38E12B82257AE3600A84040 /* Redux+Saga+Await.swift */; };
 		D3943ED81FA32D5600898233 /* CompleteRedux.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D3943ECE1FA32D5600898233 /* CompleteRedux.framework */; };
+		D3AE8ECD22CA82DD008F6268 /* Redux+Saga+Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3AE8ECC22CA82DD008F6268 /* Redux+Saga+Merge.swift */; };
 		D3E02A4F2257C1C500AA1F41 /* ReduxSagaTest+TakeEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E02A4E2257C1C500AA1F41 /* ReduxSagaTest+TakeEffect.swift */; };
 		EE0958A322AEDC6800D01960 /* Redux+Saga+FlatMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0958A222AEDC6800D01960 /* Redux+Saga+FlatMap.swift */; };
 		EE0958A522AEE0D300D01960 /* Redux+Saga+Debounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0958A422AEE0D300D01960 /* Redux+Saga+Debounce.swift */; };
@@ -145,6 +146,7 @@
 		D3943ECE1FA32D5600898233 /* CompleteRedux.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CompleteRedux.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3943ED71FA32D5600898233 /* CompleteReduxTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CompleteReduxTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3943EDE1FA32D5600898233 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D3AE8ECC22CA82DD008F6268 /* Redux+Saga+Merge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Redux+Saga+Merge.swift"; sourceTree = "<group>"; };
 		D3D31A3522C874BF00B668FD /* RxBlocking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RxBlocking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3E02A4E2257C1C500AA1F41 /* ReduxSagaTest+TakeEffect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReduxSagaTest+TakeEffect.swift"; sourceTree = "<group>"; };
 		E888B6124BC66F50DF0E84E1 /* Pods-CompleteRedux-Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CompleteRedux-Demo.release.xcconfig"; path = "Target Support Files/Pods-CompleteRedux-Demo/Pods-CompleteRedux-Demo.release.xcconfig"; sourceTree = "<group>"; };
@@ -404,6 +406,7 @@
 				EEAABD2D221D174500543DE2 /* Redux+Saga+Effects.swift */,
 				EEAABD34221D174500543DE2 /* Redux+Saga+Empty.swift */,
 				EE0958A222AEDC6800D01960 /* Redux+Saga+FlatMap.swift */,
+				D3AE8ECC22CA82DD008F6268 /* Redux+Saga+Merge.swift */,
 				EE7111DA2235756300532177 /* Redux+Saga+Output.swift */,
 				EEAABD33221D174500543DE2 /* Redux+Saga+Put.swift */,
 				EEAABD28221D174500543DE2 /* Redux+Saga+Select.swift */,
@@ -907,6 +910,7 @@
 				EE3A11B4221D7F4A0023B445 /* Redux+Saga+Select.swift in Sources */,
 				EE3A11B6221D7F4A0023B445 /* Redux+Middleware+Saga.swift in Sources */,
 				EE7111DB2235756400532177 /* Redux+Saga+Output.swift in Sources */,
+				D3AE8ECD22CA82DD008F6268 /* Redux+Saga+Merge.swift in Sources */,
 				EE3A11B9221D7F4A0023B445 /* Redux+Saga+Effects.swift in Sources */,
 				EE567CF22236BF5200E907F4 /* Redux+UniqueID.swift in Sources */,
 				EE3A11BB221D7F4A0023B445 /* Redux+Saga+Call.swift in Sources */,

--- a/CompleteRedux/Middleware+Saga/Redux+Saga+Effects.swift
+++ b/CompleteRedux/Middleware+Saga/Redux+Saga+Effects.swift
@@ -13,6 +13,24 @@ import RxSwift
 public final class SagaEffects {
   init() {}
   
+  /// Create an AllEffect from a sequence of other effects.
+  ///
+  /// - Parameter effects: A sequence of SagaEffects.
+  /// - Returns: An AllEffect instance.
+  public static func all<S>(_ effects: S) -> AllEffect<S.Element.R> where
+    S: Sequence, S.Element: SagaEffectConvertibleType
+  {
+    return AllEffect(effects)
+  }
+  
+  /// Create an AllEffect from vararg effects.
+  ///
+  /// - Parameter effects: A vararg of SagaEffects.
+  /// - Returns: An AllEffect instance.
+  public static func all<R>(_ effects: SagaEffect<R>...) -> AllEffect<R> {
+    return SagaEffects.all(effects)
+  }
+  
   /// Create an await effect with a creator function.
   ///
   /// - Parameter creator: Function that await for results from multiple effects.

--- a/CompleteRedux/Middleware+Saga/Redux+Saga+Merge.swift
+++ b/CompleteRedux/Middleware+Saga/Redux+Saga+Merge.swift
@@ -1,0 +1,25 @@
+//
+//  Redux+Saga+Merge.swift
+//  CompleteRedux
+//
+//  Created by Hai Pham on 2/7/19.
+//  Copyright © 2019 Hai Pham. All rights reserved.
+//
+
+import RxSwift
+
+/// Effects whose output emits values from multiple other outputs produced by
+/// other effects.
+public final class AllEffect<R>: SagaEffect<R> {
+  private let effects: [SagaEffect<R>]
+  
+  init<S>(_ effects: S) where S: Sequence, S.Element: SagaEffectConvertibleType, S.Element.R == R {
+    self.effects = effects.map({$0.asEffect()})
+  }
+  
+  override public func invoke(_ input: SagaInput) -> SagaOutput<R> {
+    let outputs = self.effects.map({$0.invoke(input)})
+    let stream = Observable.merge(outputs.map({$0.source}))
+    return SagaOutput(input.monitor, stream)
+  }
+}

--- a/CompleteRedux/Middleware+Saga/Redux+Saga+Output.swift
+++ b/CompleteRedux/Middleware+Saga/Redux+Saga+Output.swift
@@ -10,7 +10,7 @@ import RxSwift
 import RxBlocking
 
 /// Output for each saga effect. This is simply a wrapper for Observable.
-public final class SagaOutput<T>: Awaitable<T> {
+public final class SagaOutput<T>: Awaitable<T> {  
   let monitor: SagaMonitorType
   let onAction: AwaitableReduxDispatcher
   let source: Observable<T>


### PR DESCRIPTION
Add `AllEffect` to merge emissions from multiple `SagaEffect`:
```swift
SagaEffects.all(
  SagaEffects.takeAction({(action: Action) in action.value}),
  SagaEffects.takeAction({(action: Action) in action.value}),
  SagaEffects.takeAction({(action: Action) in action.value})
)
```
This helps when we want to control a module's Saga lifecycle.